### PR TITLE
remove legacy vault credential fetch from creds_builder (v1.6.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Legion::Data Changelog
 
+## [1.6.7] - 2026-03-26
+
+### Removed
+- Legacy Vault credential fetch in `Connection#creds_builder` — hardcoded `database/creds/legion` path removed. Database credentials are now exclusively managed by the LeaseManager via `lease://postgresql#username` / `lease://postgresql#password` URI references in data settings.
+
 ## [1.6.6] - 2026-03-25
 
 ### Added

--- a/lib/legion/data/connection.rb
+++ b/lib/legion/data/connection.rb
@@ -259,14 +259,6 @@ module Legion
           port = final_creds[:port]
           merge_tls_creds(final_creds, adapter: adapter, port: port)
 
-          return final_creds if Legion::Settings[:vault].nil?
-
-          if Legion::Settings[:vault][:connected] && ::Vault.sys.mounts.key?(:database)
-            temp_vault_creds = Legion::Crypt.read('database/creds/legion')
-            final_creds[:user] = temp_vault_creds[:username]
-            final_creds[:password] = temp_vault_creds[:password]
-          end
-
           final_creds
         end
 

--- a/lib/legion/data/version.rb
+++ b/lib/legion/data/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Data
-    VERSION = '1.6.6'
+    VERSION = '1.6.7'
   end
 end


### PR DESCRIPTION
## Summary
- Removed legacy Vault credential fetch in `Connection#creds_builder` which hardcoded the wrong path (`database/creds/legion` instead of `postgresql/creds/agent`)
- Database credentials are already managed by the LeaseManager via `lease://postgresql#username` / `lease://postgresql#password` in data settings

## Test plan
- [x] `bundle exec rspec` — 395 examples, 0 failures
- [x] `bundle exec rubocop` — 0 offenses