### PR TITLE
add migration 061: versioning and expiry columns for apollo_entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+## [1.6.18] - 2026-03-30
+
+### Added
+- Migration 061: versioning and expiry columns on `apollo_entries` — `parent_knowledge_id` (UUID), `is_latest` (boolean, default true), `supersession_type` (VARCHAR 20), `expires_at` (timestamptz), `forget_reason` (VARCHAR 255), `is_inference` (boolean, default false) — postgres only
+- Migration 061: 4 named indexes including partial indexes: `idx_apollo_parent_knowledge`, `idx_apollo_version_chain` (partial WHERE is_latest), `idx_apollo_expiry` (partial WHERE expires_at IS NOT NULL), `idx_apollo_inference` (partial WHERE is_inference)
+- Spec for migration 061 covering column presence, types, nullability, defaults, all 4 indexes, and idempotency
+
 ## [1.6.17] - 2026-03-30
 
 ### Added

--- a/lib/legion/data/migrations/061_add_versioning_and_expiry.rb
+++ b/lib/legion/data/migrations/061_add_versioning_and_expiry.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    next unless adapter_scheme == :postgres
+    next unless table_exists?(:apollo_entries)
+
+    existing_columns = schema(:apollo_entries).map(&:first)
+
+    alter_table(:apollo_entries) do
+      add_column :parent_knowledge_id, :uuid, null: true unless existing_columns.include?(:parent_knowledge_id)
+      add_column :is_latest, :boolean, null: false, default: true unless existing_columns.include?(:is_latest)
+      add_column :supersession_type, String, size: 20, null: true unless existing_columns.include?(:supersession_type)
+      add_column :expires_at, :timestamptz, null: true unless existing_columns.include?(:expires_at)
+      add_column :forget_reason, String, size: 255, null: true unless existing_columns.include?(:forget_reason)
+      add_column :is_inference, :boolean, null: false, default: false unless existing_columns.include?(:is_inference)
+    end
+
+    add_index :apollo_entries, :parent_knowledge_id, name: :idx_apollo_parent_knowledge, if_not_exists: true
+    add_index :apollo_entries, %i[parent_knowledge_id is_latest],
+              name:          :idx_apollo_version_chain,
+              where:         Sequel.lit('is_latest = true'),
+              if_not_exists: true
+    add_index :apollo_entries, :expires_at,
+              name:          :idx_apollo_expiry,
+              where:         Sequel.lit("expires_at IS NOT NULL AND status != 'archived'"),
+              if_not_exists: true
+    add_index :apollo_entries, :is_inference,
+              name:          :idx_apollo_inference,
+              where:         Sequel.lit('is_inference = true'),
+              if_not_exists: true
+  end
+
+  down do
+    next unless adapter_scheme == :postgres
+    next unless table_exists?(:apollo_entries)
+
+    existing_columns = schema(:apollo_entries).map(&:first)
+
+    alter_table(:apollo_entries) do
+      drop_column :parent_knowledge_id if existing_columns.include?(:parent_knowledge_id)
+      drop_column :is_latest if existing_columns.include?(:is_latest)
+      drop_column :supersession_type if existing_columns.include?(:supersession_type)
+      drop_column :expires_at if existing_columns.include?(:expires_at)
+      drop_column :forget_reason if existing_columns.include?(:forget_reason)
+      drop_column :is_inference if existing_columns.include?(:is_inference)
+    end
+  end
+end

--- a/lib/legion/data/version.rb
+++ b/lib/legion/data/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Data
-    VERSION = '1.6.17'
+    VERSION = '1.6.18'
   end
 end

--- a/spec/migrations/061_add_versioning_and_expiry_spec.rb
+++ b/spec/migrations/061_add_versioning_and_expiry_spec.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Migration 061: add versioning and expiry columns to apollo_entries' do
+  let(:db) { Legion::Data::Connection.sequel }
+
+  before(:all) do
+    migration_path = File.expand_path('../../lib/legion/data/migrations', __dir__)
+    Sequel::Migrator.run(Legion::Data::Connection.sequel, migration_path, target: 61)
+  end
+
+  it 'migration file exists' do
+    migration_path = File.expand_path('../../lib/legion/data/migrations', __dir__)
+    expect(File.exist?(File.join(migration_path, '061_add_versioning_and_expiry.rb'))).to be true
+  end
+
+  context 'when postgres', if: Legion::Data::Connection.adapter == :postgres do
+    let(:columns) { db.schema(:apollo_entries).to_h }
+
+    describe 'parent_knowledge_id column' do
+      it 'exists on apollo_entries' do
+        expect(columns.keys).to include(:parent_knowledge_id)
+      end
+
+      it 'is nullable' do
+        expect(columns[:parent_knowledge_id][:allow_null]).to be true
+      end
+
+      it 'is a uuid type' do
+        expect(columns[:parent_knowledge_id][:db_type]).to match(/uuid/i)
+      end
+    end
+
+    describe 'is_latest column' do
+      it 'exists on apollo_entries' do
+        expect(columns.keys).to include(:is_latest)
+      end
+
+      it 'is not nullable' do
+        expect(columns[:is_latest][:allow_null]).to be false
+      end
+
+      it 'defaults to true' do
+        expect(columns[:is_latest][:ruby_default]).to eq('true').or eq(true)
+      end
+    end
+
+    describe 'supersession_type column' do
+      it 'exists on apollo_entries' do
+        expect(columns.keys).to include(:supersession_type)
+      end
+
+      it 'is nullable' do
+        expect(columns[:supersession_type][:allow_null]).to be true
+      end
+
+      it 'is a varchar (string type)' do
+        expect(columns[:supersession_type][:db_type]).to match(/varchar|character varying/i)
+      end
+    end
+
+    describe 'expires_at column' do
+      it 'exists on apollo_entries' do
+        expect(columns.keys).to include(:expires_at)
+      end
+
+      it 'is nullable' do
+        expect(columns[:expires_at][:allow_null]).to be true
+      end
+    end
+
+    describe 'forget_reason column' do
+      it 'exists on apollo_entries' do
+        expect(columns.keys).to include(:forget_reason)
+      end
+
+      it 'is nullable' do
+        expect(columns[:forget_reason][:allow_null]).to be true
+      end
+
+      it 'is a varchar (string type)' do
+        expect(columns[:forget_reason][:db_type]).to match(/varchar|character varying/i)
+      end
+    end
+
+    describe 'is_inference column' do
+      it 'exists on apollo_entries' do
+        expect(columns.keys).to include(:is_inference)
+      end
+
+      it 'is not nullable' do
+        expect(columns[:is_inference][:allow_null]).to be false
+      end
+
+      it 'defaults to false' do
+        expect(columns[:is_inference][:ruby_default]).to eq('false').or eq(false)
+      end
+    end
+
+    describe 'indexes' do
+      it 'has named index on parent_knowledge_id' do
+        expect(db.indexes(:apollo_entries)).to have_key(:idx_apollo_parent_knowledge)
+      end
+
+      it 'parent_knowledge index covers the parent_knowledge_id column' do
+        idx = db.indexes(:apollo_entries)[:idx_apollo_parent_knowledge]
+        expect(idx[:columns]).to include(:parent_knowledge_id)
+      end
+
+      it 'has named version chain index' do
+        expect(db.indexes(:apollo_entries)).to have_key(:idx_apollo_version_chain)
+      end
+
+      it 'version chain index covers parent_knowledge_id and is_latest' do
+        idx = db.indexes(:apollo_entries)[:idx_apollo_version_chain]
+        expect(idx[:columns]).to include(:parent_knowledge_id)
+        expect(idx[:columns]).to include(:is_latest)
+      end
+
+      it 'has named expiry index' do
+        expect(db.indexes(:apollo_entries)).to have_key(:idx_apollo_expiry)
+      end
+
+      it 'expiry index covers expires_at column' do
+        idx = db.indexes(:apollo_entries)[:idx_apollo_expiry]
+        expect(idx[:columns]).to include(:expires_at)
+      end
+
+      it 'has named inference index' do
+        expect(db.indexes(:apollo_entries)).to have_key(:idx_apollo_inference)
+      end
+
+      it 'inference index covers is_inference column' do
+        idx = db.indexes(:apollo_entries)[:idx_apollo_inference]
+        expect(idx[:columns]).to include(:is_inference)
+      end
+    end
+
+    it 'is idempotent when run twice' do
+      migration_path = File.expand_path('../../lib/legion/data/migrations', __dir__)
+      expect do
+        Sequel::Migrator.run(db, migration_path, target: 60)
+        Sequel::Migrator.run(db, migration_path, target: 61)
+      end.not_to raise_error
+    end
+  end
+
+  context 'when not postgres', unless: Legion::Data::Connection.adapter == :postgres do
+    it 'apollo_entries table does not exist (postgres-only feature)' do
+      expect(db.table_exists?(:apollo_entries)).to be false
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds migration 061 with 6 new columns on `apollo_entries`: `parent_knowledge_id`, `is_latest`, `supersession_type`, `expires_at`, `forget_reason`, `is_inference`
- 4 named indexes including partial indexes for version chain and expiry queries
- Postgres-only guard and idempotency checks matching migration 060 pattern

Closes #12

## Downstream

- LegionIO/legion-apollo#7 (versioned knowledge) — unblocked by this
- LegionIO/legion-apollo#8 (temporal expiry) — unblocked by this
- LegionIO/legion-apollo#9 (inference tagging) — unblocked by this

## Test plan

- [ ] Migration applies cleanly on fresh and existing DB
- [ ] All columns have correct types, defaults, and nullability
- [ ] All indexes created with correct column coverage
- [ ] Idempotency: down then up succeeds
- [ ] Existing queries unaffected