### PR TITLE
Dev v1.6.19 logging uplift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 ### Fixed
 - Added `handle_exception(...)` coverage to rescue paths across non-API data modules so failures are logged consistently without changing existing fallback behavior
 - Added compatibility fallback for `handle_exception` when older `legion-logging` releases are present in the runtime
+- Included `metadata_json` in EventStore integrity hashes for new events while preserving verification compatibility for legacy rows
+- Fixed encrypted Sequel columns to re-encrypt newly-created rows with their persisted primary key and maintain legacy read compatibility
+- Hardened spool persistence with atomic writes, deterministic replay ordering, and corrupt-file quarantine during read/flush
 - Updated partition manager specs to assert against helper-backed logger behavior
 
 ## [1.6.18] - 2026-03-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+## [1.6.19] - 2026-04-02
+
+### Changed
+- Logging uplift across non-API `lib/` modules to use `Legion::Logging::Helper` and `log.*` instead of direct `Legion::Logging.*` calls
+- Removed direct `log_info` / `log_warn` wrapper usage in partition management and aligned logging with helper-backed tagged loggers
+- Added broader info-level operational logs for archival, retention, spool, extract, storage-tier, and partition workflows
+
+### Fixed
+- Added `handle_exception(...)` coverage to rescue paths across non-API data modules so failures are logged consistently without changing existing fallback behavior
+- Added compatibility fallback for `handle_exception` when older `legion-logging` releases are present in the runtime
+- Updated partition manager specs to assert against helper-backed logger behavior
+
 ## [1.6.18] - 2026-03-30
 
 ### Added

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@
 source 'https://rubygems.org'
 
 gemspec
-gem 'legion-logging', git: 'https://github.com/LegionIO/legion-logging.git', tag: 'v1.5.0'
 
 group :test do
   gem 'rake'

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,8 @@
 source 'https://rubygems.org'
 
 gemspec
+gem 'legion-logging', git: 'https://github.com/LegionIO/legion-logging.git', tag: 'v1.5.0'
+
 group :test do
   gem 'rake'
   gem 'rspec'

--- a/legion-data.gemspec
+++ b/legion-data.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'csv', '>= 3.2'
   spec.add_dependency 'legion-logging', '>= 1.5.0'
-  spec.add_dependency 'legion-settings', '>= 1.3.12'
+  spec.add_dependency 'legion-settings', '>= 1.3.26'
   spec.add_dependency 'sequel', '>= 5.70'
   spec.add_dependency 'sqlite3', '>= 2.0'
 end

--- a/legion-data.gemspec
+++ b/legion-data.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   }
 
   spec.add_dependency 'csv', '>= 3.2'
-  spec.add_dependency 'legion-logging', '>= 1.2.8'
+  spec.add_dependency 'legion-logging', '>= 1.5.0'
   spec.add_dependency 'legion-settings', '>= 1.3.12'
   spec.add_dependency 'sequel', '>= 5.70'
   spec.add_dependency 'sqlite3', '>= 2.0'

--- a/lib/legion/data.rb
+++ b/lib/legion/data.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'legion/logging/helper'
 require 'legion/data/version'
 require 'legion/data/settings'
 require 'sequel'
@@ -16,16 +17,38 @@ require_relative 'data/rls'
 require_relative 'data/extract'
 require_relative 'data/audit_record'
 
+unless Legion::Logging::Helper.method_defined?(:handle_exception)
+  module Legion
+    module Logging
+      module Helper
+        def handle_exception(exception, task_id: nil, level: :error, handled: true, **opts)
+          context = opts.map { |key, value| "#{key}=#{value.inspect}" }.join(' ')
+          message = "#{exception.class}: #{exception.message}"
+          message = "#{message} task_id=#{task_id}" if task_id
+          message = "#{message} handled=#{handled}"
+          message = "#{message} #{context}" unless context.empty?
+          warn("[#{level}] #{message}")
+        rescue StandardError => e
+          warn("handle_exception fallback failed: #{e.class}: #{e.message}")
+        end
+      end
+    end
+  end
+end
+
 module Legion
   module Data
     class << self
+      include Legion::Logging::Helper
+
       def setup
+        log.info 'Legion::Data setup starting'
         connection_setup
         migrate
         load_models
         setup_cache
         setup_local
-        Legion::Logging.info 'Legion::Data setup complete' if defined?(Legion::Logging)
+        log.info 'Legion::Data setup complete'
       end
 
       def connection_setup
@@ -59,7 +82,8 @@ module Legion
 
       def connected?
         Legion::Settings[:data][:connected] == true
-      rescue StandardError
+      rescue StandardError => e
+        handle_exception(e, level: :debug, handled: true, operation: :connected?)
         false
       end
 
@@ -75,7 +99,8 @@ module Legion
         @write_privileges[table_name] = connection
                                         .fetch("SELECT has_table_privilege(current_user, ?, 'INSERT') AS can", table_name.to_s)
                                         .first[:can] == true
-      rescue StandardError
+      rescue StandardError => e
+        handle_exception(e, level: :warn, handled: true, operation: :can_write?, table: table_name)
         @write_privileges[table_name] = false if @write_privileges
         false
       end
@@ -92,7 +117,8 @@ module Legion
         @read_privileges[table_name] = connection
                                        .fetch("SELECT has_table_privilege(current_user, ?, 'SELECT') AS can", table_name.to_s)
                                        .first[:can] == true
-      rescue StandardError
+      rescue StandardError => e
+        handle_exception(e, level: :warn, handled: true, operation: :can_read?, table: table_name)
         @read_privileges[table_name] = false if @read_privileges
         false
       end
@@ -111,17 +137,18 @@ module Legion
       def setup_static_cache
         [Model::Extension, Model::Runner, Model::Function].each do |model|
           model.plugin :static_cache
-          Legion::Logging.debug("StaticCache enabled for #{model}") if defined?(Legion::Logging)
+          log.debug("StaticCache enabled for #{model}")
         rescue StandardError => e
-          Legion::Logging.warn("StaticCache failed for #{model}: #{e.message}") if defined?(Legion::Logging)
+          handle_exception(e, level: :warn, operation: :setup_static_cache, model: model.to_s)
         end
-        Legion::Logging.info 'Legion::Data static cache loaded' if defined?(Legion::Logging)
+        log.info 'Legion::Data static cache loaded'
       end
 
       def reload_static_cache
         [Model::Extension, Model::Runner, Model::Function].each do |model|
           model.load_cache if model.respond_to?(:load_cache)
         end
+        log.info 'Legion::Data static cache reloaded'
       end
 
       def setup_external_cache
@@ -132,17 +159,17 @@ module Legion
           Model::Setting      => ttl
         }.each do |model, model_ttl|
           model.plugin :caching, ::Legion::Cache, ttl: model_ttl
-          Legion::Logging.debug("Caching enabled for #{model} (ttl: #{model_ttl})") if defined?(Legion::Logging)
+          log.debug("Caching enabled for #{model} (ttl: #{model_ttl})")
         rescue StandardError => e
-          Legion::Logging.warn("Caching failed for #{model}: #{e.message}") if defined?(Legion::Logging)
+          handle_exception(e, level: :warn, operation: :setup_external_cache, model: model.to_s, ttl: model_ttl)
         end
-        Legion::Logging.info 'Legion::Data external cache connected' if defined?(Legion::Logging)
+        log.info 'Legion::Data external cache connected'
       end
 
       def shutdown
         Legion::Data::Local.shutdown if defined?(Legion::Data::Local) && Legion::Data::Local.connected?
         Legion::Data::Connection.shutdown
-        Legion::Logging.info 'Legion::Data shutdown complete' if defined?(Legion::Logging)
+        log.info 'Legion::Data shutdown complete'
       end
 
       private
@@ -152,7 +179,7 @@ module Legion
 
         Legion::Data::Local.setup
       rescue StandardError => e
-        Legion::Logging.warn "Legion::Data::Local failed to setup: #{e.message}" if defined?(Legion::Logging)
+        handle_exception(e, level: :warn, operation: :setup_local)
       end
     end
   end

--- a/lib/legion/data/archival.rb
+++ b/lib/legion/data/archival.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'legion/logging/helper'
 require_relative 'archival/policy'
 
 module Legion
@@ -11,21 +12,28 @@ module Legion
       }.freeze
 
       class << self
+        include Legion::Logging::Helper
+
         def archive!(policy: Policy.new, dry_run: false)
+          log.info "Archival run started dry_run=#{dry_run} tables=#{policy.tables.size}"
           results = {}
           policy.tables.each do |table_name|
             table = table_name.to_sym
             archive_table = ARCHIVE_TABLE_MAP[table]
             next unless archive_table && db_ready?(table) && db_ready?(archive_table)
 
-            Legion::Logging.info "Archiving #{table} -> #{archive_table} (cutoff: #{policy.warm_cutoff}, dry_run: #{dry_run})" if defined?(Legion::Logging)
+            log.info "Archiving #{table} -> #{archive_table} (cutoff: #{policy.warm_cutoff}, dry_run: #{dry_run})"
             count = archive_table!(
               source: table, destination: archive_table,
               cutoff: policy.warm_cutoff, batch_size: policy.batch_size, dry_run: dry_run
             )
             results[table] = count
           end
+          log.info "Archival run completed tables=#{results.keys.join(',')}" unless results.empty?
           results
+        rescue StandardError => e
+          handle_exception(e, level: :error, handled: false, operation: :archive!, dry_run: dry_run)
+          raise
         end
 
         def restore(table:, ids:)
@@ -46,8 +54,11 @@ module Legion
             end
             conn[archive_table].where(original_id: ids).delete
           end
-          Legion::Logging.info "Restored #{restored} row(s) from #{archive_table} -> #{source_table}" if defined?(Legion::Logging)
+          log.info "Restored #{restored} row(s) from #{archive_table} -> #{source_table}"
           restored
+        rescue StandardError => e
+          handle_exception(e, level: :error, handled: false, operation: :restore, table: source_table, ids: Array(ids))
+          raise
         end
 
         def search(table:, where: {})
@@ -55,10 +66,14 @@ module Legion
           archive_table = ARCHIVE_TABLE_MAP[source_table]
           return [] unless db_ready?(source_table)
 
+          log.info "Archival search table=#{source_table} where_keys=#{where.keys.join(',')}"
           conn = Legion::Data.connection
           hot = conn[source_table].where(where).all
           warm = db_ready?(archive_table) ? conn[archive_table].where(where).all : []
           hot + warm
+        rescue StandardError => e
+          handle_exception(e, level: :error, handled: false, operation: :search, table: source_table, where_keys: where.keys)
+          raise
         end
 
         def archive_completed_tasks(days_old: 90, batch_size: 1000)
@@ -92,11 +107,15 @@ module Legion
             end
           end
 
-          Legion::Logging.info "archive_completed_tasks: archived #{count} tasks (cutoff: #{cutoff.iso8601})" if defined?(Legion::Logging)
+          log.info "archive_completed_tasks: archived #{count} tasks (cutoff: #{cutoff.iso8601})"
           { archived: count, cutoff: cutoff.iso8601 }
+        rescue StandardError => e
+          handle_exception(e, level: :error, handled: false, operation: :archive_completed_tasks, days_old: days_old, batch_size: batch_size)
+          raise
         end
 
         def run_scheduled_archival
+          log.info 'Running scheduled archival'
           results = {}
           results[:tasks] = archive_completed_tasks
 
@@ -107,7 +126,11 @@ module Legion
             )
           end
 
+          log.info "Scheduled archival completed keys=#{results.keys.join(',')}"
           results
+        rescue StandardError => e
+          handle_exception(e, level: :error, handled: false, operation: :run_scheduled_archival)
+          raise
         end
 
         private
@@ -135,7 +158,7 @@ module Legion
         def db_ready?(table)
           defined?(Legion::Data) && Legion::Data.connection&.table_exists?(table)
         rescue StandardError => e
-          Legion::Logging.debug("Archival#db_ready? check failed for #{table}: #{e.message}") if defined?(Legion::Logging)
+          handle_exception(e, level: :warn, handled: true, operation: :archival_db_ready, table: table)
           false
         end
       end

--- a/lib/legion/data/archival/policy.rb
+++ b/lib/legion/data/archival/policy.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'legion/logging/helper'
+
 module Legion
   module Data
     module Archival
@@ -37,6 +39,10 @@ module Legion
           Time.now - (cold_after_days * 86_400)
         end
 
+        class << self
+          include Legion::Logging::Helper
+        end
+
         def self.from_settings
           return new unless defined?(Legion::Settings)
 
@@ -46,7 +52,7 @@ module Legion
 
           new(**archival.slice(:warm_after_days, :cold_after_days, :batch_size, :tables))
         rescue StandardError => e
-          Legion::Logging.warn("Policy.from_settings failed: #{e.message}") if defined?(Legion::Logging)
+          handle_exception(e, level: :warn, handled: true, operation: :policy_from_settings)
           new
         end
       end

--- a/lib/legion/data/archiver.rb
+++ b/lib/legion/data/archiver.rb
@@ -202,7 +202,7 @@ module Legion
           handle_exception(e, level: :error, handled: false, operation: :upload_azure, table: table, year: year, month: month, batch_n: batch_n)
           raise
         rescue StandardError => e
-          handle_exception(e, level: :error, handled: true, operation: :upload_azure, table: table, year: year, month: month, batch_n: batch_n)
+          handle_exception(e, level: :error, handled: false, operation: :upload_azure, table: table, year: year, month: month, batch_n: batch_n)
           raise UploadError, "Azure upload failed: #{e.message}"
         end
 

--- a/lib/legion/data/archiver.rb
+++ b/lib/legion/data/archiver.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'legion/logging/helper'
 require 'digest'
 require 'fileutils'
 require 'json'
@@ -13,62 +14,41 @@ module Legion
       class UploadError < StandardError; end
 
       class << self
+        include Legion::Logging::Helper
+
         def archive_table(table:, retention_days: 90, batch_size: 1000, storage_backend: nil)
           return { skipped: true, reason: 'not_postgres' } unless postgres?
 
-          Legion::Logging.info "Archiving table #{table} (retention: #{retention_days}d)" if defined?(Legion::Logging)
+          log.info "Archiving table #{table} (retention: #{retention_days}d)"
 
           conn = Legion::Data.connection
           cutoff = Time.now - (retention_days * 86_400)
-          now = Time.now.utc
+          archive_results = archive_batches(
+            conn:            conn,
+            table:           table,
+            cutoff:          cutoff,
+            batch_size:      batch_size,
+            storage_backend: storage_backend
+          )
 
-          batches = 0
-          total_rows = 0
-          paths = []
-          batch_n = 0
-
-          loop do
-            batch_n += 1
-            rows = conn[table].where { created_at < cutoff }.limit(batch_size).all
-            break if rows.empty?
-
-            ids = rows.map { |r| r[:id] }
-            jsonl = serialize_rows(rows)
-            compressed = gzip_compress(jsonl)
-            checksum = Digest::SHA256.hexdigest(compressed)
-            batch_id = SecureRandom.uuid
-
-            path = upload_batch(
-              data:    compressed,
-              table:   table.to_s,
-              year:    now.year,
-              month:   now.month,
-              batch_n: batch_n,
-              backend: storage_backend
-            )
-
-            conn.transaction do
-              conn[:archive_manifest].insert(
-                batch_id:     batch_id,
-                source_table: table.to_s,
-                row_count:    rows.size,
-                checksum:     checksum,
-                storage_path: path,
-                archived_at:  now
-              )
-              conn[table].where(id: ids).delete
-            end
-
-            batches += 1
-            total_rows += rows.size
-            paths << path
-          end
-
-          Legion::Logging.info "Archived #{total_rows} rows from #{table} in #{batches} batch(es)" if defined?(Legion::Logging)
-          { batches: batches, total_rows: total_rows, paths: paths }
+          log.info "Archived #{archive_results[:total_rows]} rows from #{table} in #{archive_results[:batches]} batch(es)"
+          archive_results
+        rescue StandardError => e
+          handle_exception(
+            e,
+            level:           :error,
+            handled:         false,
+            operation:       :archive_table,
+            table:           table,
+            retention_days:  retention_days,
+            batch_size:      batch_size,
+            storage_backend: storage_backend
+          )
+          raise
         end
 
         def upload_batch(data:, table:, year:, month:, batch_n:, backend:)
+          log.info "Archiver storing batch table=#{table} backend=#{backend || :tmpdir} year=#{year} month=#{month} batch=#{batch_n}"
           case backend
           when :s3
             upload_s3(data: data, table: table, year: year, month: month, batch_n: batch_n)
@@ -111,6 +91,72 @@ module Legion
           rows.map { |row| json_dump(row) }.join("\n")
         end
 
+        def archive_batches(conn:, table:, cutoff:, batch_size:, storage_backend:)
+          now = Time.now.utc
+          batches = 0
+          total_rows = 0
+          paths = []
+
+          loop do
+            batch_result = archive_batch(
+              conn:            conn,
+              table:           table,
+              cutoff:          cutoff,
+              batch_size:      batch_size,
+              batch_n:         batches + 1,
+              now:             now,
+              storage_backend: storage_backend
+            )
+            break unless batch_result
+
+            batches += 1
+            total_rows += batch_result[:row_count]
+            paths << batch_result[:path]
+          end
+
+          { batches: batches, total_rows: total_rows, paths: paths }
+        end
+
+        def archive_batch(conn:, table:, cutoff:, batch_size:, batch_n:, now:, storage_backend:)
+          rows = conn[table].where { created_at < cutoff }.limit(batch_size).all
+          return if rows.empty?
+
+          compressed = gzip_compress(serialize_rows(rows))
+          path = upload_batch(
+            data:    compressed,
+            table:   table.to_s,
+            year:    now.year,
+            month:   now.month,
+            batch_n: batch_n,
+            backend: storage_backend
+          )
+
+          record_archived_batch(
+            conn:       conn,
+            table:      table,
+            rows:       rows,
+            compressed: compressed,
+            path:       path,
+            now:        now
+          )
+
+          { row_count: rows.size, path: path }
+        end
+
+        def record_archived_batch(conn:, table:, rows:, compressed:, path:, now:)
+          conn.transaction do
+            conn[:archive_manifest].insert(
+              batch_id:     SecureRandom.uuid,
+              source_table: table.to_s,
+              row_count:    rows.size,
+              checksum:     Digest::SHA256.hexdigest(compressed),
+              storage_path: path,
+              archived_at:  now
+            )
+            conn[table].where(id: rows.map { |row| row[:id] }).delete
+          end
+        end
+
         def json_dump(obj)
           if defined?(Legion::JSON)
             Legion::JSON.dump(obj)
@@ -133,11 +179,13 @@ module Legion
 
           key = "legion-archive/#{table}/#{year}/#{month}/batch_#{batch_n}.jsonl.gz"
           Legion::Extensions::S3::Runners::Put.run(key: key, body: data)
+          log.info "Archiver uploaded batch to s3 key=#{key}"
           "s3://#{key}"
-        rescue UploadError
+        rescue UploadError => e
+          handle_exception(e, level: :error, handled: false, operation: :upload_s3, table: table, year: year, month: month, batch_n: batch_n)
           raise
         rescue StandardError => e
-          Legion::Logging.warn "S3 upload failed: #{e.message}" if defined?(Legion::Logging)
+          handle_exception(e, level: :error, handled: true, operation: :upload_s3, table: table, year: year, month: month, batch_n: batch_n)
           raise UploadError, "S3 upload failed: #{e.message}"
         end
 
@@ -148,11 +196,13 @@ module Legion
 
           blob_name = "legion-archive/#{table}/#{year}/#{month}/batch_#{batch_n}.jsonl.gz"
           Legion::Extensions::AzureStorage::Runners::Upload.run(blob_name: blob_name, data: data)
+          log.info "Archiver uploaded batch to azure blob=#{blob_name}"
           "azure://#{blob_name}"
-        rescue UploadError
+        rescue UploadError => e
+          handle_exception(e, level: :error, handled: false, operation: :upload_azure, table: table, year: year, month: month, batch_n: batch_n)
           raise
         rescue StandardError => e
-          Legion::Logging.warn "Azure upload failed: #{e.message}" if defined?(Legion::Logging)
+          handle_exception(e, level: :error, handled: true, operation: :upload_azure, table: table, year: year, month: month, batch_n: batch_n)
           raise UploadError, "Azure upload failed: #{e.message}"
         end
 
@@ -161,8 +211,10 @@ module Legion
           FileUtils.mkdir_p(dir)
           path = File.join(dir, "batch_#{batch_n}.jsonl.gz")
           File.binwrite(path, data)
+          log.info "Archiver stored batch locally path=#{path}"
           "file://#{path}"
         rescue StandardError => e
+          handle_exception(e, level: :error, handled: true, operation: :upload_tmpdir, table: table, year: year, month: month, batch_n: batch_n)
           raise UploadError, "Tmpdir upload failed: #{e.message}"
         end
       end

--- a/lib/legion/data/audit_record.rb
+++ b/lib/legion/data/audit_record.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'legion/logging/helper'
 require 'digest'
 
 module Legion
@@ -8,6 +9,8 @@ module Legion
       GENESIS_HASH = ('0' * 64).freeze
 
       class << self
+        include Legion::Logging::Helper
+
         # Append a new record to the named chain. Returns the persisted record hash
         # on success, or an error hash when the database is unavailable.
         #
@@ -38,7 +41,7 @@ module Legion
               created_at:   ts
             )
 
-            Legion::Logging.debug "AuditRecord append: chain=#{chain_id} type=#{content_type} id=#{id}" if defined?(Legion::Logging)
+            log.debug "AuditRecord append: chain=#{chain_id} type=#{content_type} id=#{id}"
             { id: id, chain_id: chain_id, chain_hash: ch, parent_hash: parent_hash }
           end
         end
@@ -59,13 +62,13 @@ module Legion
           prev_hash = GENESIS_HASH
           records.each do |r|
             unless r[:parent_hash] == prev_hash
-              Legion::Logging.warn "AuditRecord chain broken: chain=#{chain_id} id=#{r[:id]}" if defined?(Legion::Logging)
+              log.warn "AuditRecord chain broken: chain=#{chain_id} id=#{r[:id]}"
               return { valid: false, broken_at: r[:id], reason: :parent_mismatch }
             end
 
             expected = compute_chain_hash(prev_hash, r[:content_hash], r[:created_at], r[:content_type])
             unless r[:chain_hash] == expected
-              Legion::Logging.warn "AuditRecord hash mismatch: chain=#{chain_id} id=#{r[:id]}" if defined?(Legion::Logging)
+              log.warn "AuditRecord hash mismatch: chain=#{chain_id} id=#{r[:id]}"
               return { valid: false, broken_at: r[:id], reason: :hash_mismatch }
             end
 
@@ -142,7 +145,7 @@ module Legion
 
           Legion::Crypt.sign(chain_hash)
         rescue StandardError => e
-          Legion::Logging.warn "AuditRecord signing failed: #{e.message}" if defined?(Legion::Logging)
+          handle_exception(e, level: :warn, handled: true, operation: :sign_record)
           nil
         end
 
@@ -163,7 +166,7 @@ module Legion
         def db_ready?
           defined?(Legion::Data) && Legion::Data.connection&.table_exists?(:audit_records)
         rescue StandardError => e
-          Legion::Logging.debug "AuditRecord#db_ready? check failed: #{e.message}" if defined?(Legion::Logging)
+          handle_exception(e, level: :warn, handled: true, operation: :audit_record_db_ready?)
           false
         end
       end

--- a/lib/legion/data/connection.rb
+++ b/lib/legion/data/connection.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'legion/logging/helper'
+
 require 'fileutils'
 require 'sequel'
 
@@ -28,6 +30,8 @@ module Legion
       # Prefixes warn-level messages with [slow-query] since Sequel uses warn
       # for queries exceeding log_warn_duration.
       class SlowQueryLogger
+        attr_reader :tagged
+
         def initialize(tagged_logger)
           @tagged = tagged_logger
         end
@@ -49,9 +53,52 @@ module Legion
         end
       end
 
+      class SegmentedTaggedLogger
+        attr_reader :segments
+
+        def initialize(segments:, logger: nil)
+          @segments = segments
+          @logger = logger || Legion::Logging
+        end
+
+        def warn(message)
+          with_segments { dispatch(:warn, message) }
+        end
+
+        def info(message)
+          with_segments { dispatch(:info, message) }
+        end
+
+        def debug(message)
+          with_segments { dispatch(:debug, message) }
+        end
+
+        def error(message)
+          with_segments { dispatch(:error, message) }
+        end
+
+        private
+
+        def dispatch(level, message)
+          return unless @logger.respond_to?(level)
+
+          @logger.public_send(level, message)
+        end
+
+        def with_segments
+          previous = Thread.current[:legion_log_segments]
+          Thread.current[:legion_log_segments] = @segments
+          yield
+        ensure
+          Thread.current[:legion_log_segments] = previous
+        end
+      end
+
       # File-based query logger that writes all SQL to a dedicated log file.
       # Isolated from the main Legion::Logging domain.
       class QueryFileLogger
+        include Legion::Logging::Helper
+
         attr_reader :path
 
         def initialize(path)
@@ -90,12 +137,15 @@ module Legion
           @mutex.synchronize do
             @file.puts "[#{Time.now.strftime('%Y-%m-%d %H:%M:%S.%L')}] #{level} #{message}"
           end
-        rescue IOError
+        rescue IOError => e
+          handle_exception(e, level: :warn, handled: true, operation: :query_file_write, path: @path)
           nil
         end
       end
 
       class << self
+        include Legion::Logging::Helper
+
         attr_accessor :sequel
 
         def adapter
@@ -104,6 +154,7 @@ module Legion
 
         def setup
           opts = sequel_opts
+          log.info { "Legion::Data::Connection setup adapter=#{adapter}" }
           @sequel = if adapter == :sqlite
                       ::Sequel.connect(opts.merge(adapter: :sqlite, database: sqlite_path))
                     else
@@ -112,18 +163,14 @@ module Legion
                       rescue StandardError => e
                         raise unless dev_fallback?
 
-                        if defined?(Legion::Logging)
-                          Legion::Logging.warn(
-                            "Shared DB unreachable (#{e.message}), dev_mode fallback to SQLite"
-                          )
-                        end
+                        handle_exception(e, level: :warn, handled: true, operation: :shared_connect, fallback: :sqlite)
                         @adapter = :sqlite
                         sqlite_opts = sequel_opts
                         ::Sequel.connect(sqlite_opts.merge(adapter: :sqlite, database: sqlite_path))
                       end
                     end
           Legion::Settings[:data][:connected] = true
-          log_connection_info if defined?(Legion::Logging)
+          log_connection_info
           configure_extensions
           connect_with_replicas
         end
@@ -140,6 +187,7 @@ module Legion
             database:  database_stats
           }
         rescue StandardError => e
+          handle_exception(e, level: :warn, handled: true, operation: :data_connection_stats, adapter: adapter)
           { connected: (data[:connected] if data.is_a?(Hash)), adapter: adapter, error: e.message }
         end
 
@@ -171,7 +219,8 @@ module Legion
           end
 
           stats.compact
-        rescue StandardError
+        rescue StandardError => e
+          handle_exception(e, level: :warn, handled: true, operation: :data_pool_stats, adapter: adapter)
           {}
         end
 
@@ -180,7 +229,7 @@ module Legion
           @query_file_logger&.close
           @query_file_logger = nil
           Legion::Settings[:data][:connected] = false
-          Legion::Logging.info 'Legion::Data connection closed' if defined?(Legion::Logging)
+          log.info 'Legion::Data connection closed'
         end
 
         def connect_with_replicas
@@ -202,7 +251,7 @@ module Legion
           end
 
           @replica_servers = replica_list.each_with_index.map { |_, idx| :"read_#{idx}" }
-          Legion::Logging.debug "Registered #{@replica_servers.size} read replica(s)" if defined?(Legion::Logging)
+          log.debug "Registered #{@replica_servers.size} read replica(s)"
         end
 
         def read_server
@@ -258,20 +307,20 @@ module Legion
 
           Legion::Settings[:data][:tls] || {}
         rescue StandardError => e
-          Legion::Logging.debug("Connection#data_tls_settings failed: #{e.message}") if defined?(Legion::Logging)
+          handle_exception(e, level: :warn, handled: true, operation: :data_tls_settings)
           {}
         end
 
         def log_connection_info
           if adapter == :sqlite
-            Legion::Logging.info "Connected to SQLite at #{sqlite_path}"
+            log.info "Connected to SQLite at #{sqlite_path}"
           else
             actual = Legion::Settings[:data][:creds] || {}
             user = actual[:user] || actual[:username] || 'unknown'
             host = actual[:host] || '127.0.0.1'
             port = actual[:port]
             db   = actual[:database] || actual[:db]
-            Legion::Logging.info "Connected to #{adapter}://#{user}@#{host}:#{port}/#{db}"
+            log.info "Connected to #{adapter}://#{user}@#{host}:#{port}/#{db}"
           end
         end
 
@@ -356,6 +405,7 @@ module Legion
           else {}
           end
         rescue StandardError => e
+          handle_exception(e, level: :warn, handled: true, operation: :data_database_stats, adapter: adapter)
           { error: e.message }
         end
 
@@ -366,7 +416,8 @@ module Legion
              cache_size busy_timeout].each do |pragma|
             val = begin
               db.fetch("PRAGMA #{pragma}").single_value
-            rescue StandardError
+            rescue StandardError => e
+              handle_exception(e, level: :warn, handled: true, operation: :sqlite_stats_pragma, pragma: pragma)
               nil
             end
             stats[pragma.to_sym] = val unless val.nil?
@@ -457,12 +508,26 @@ module Legion
             @sequel.pool.connection_expiration_timeout = data[:connection_expiration_timeout] || 14_400
           end
         rescue StandardError => e
-          Legion::Logging.warn "Failed to load connection extensions: #{e.message}" if defined?(Legion::Logging)
+          handle_exception(e, level: :warn, handled: true, operation: :configure_extensions, adapter: adapter)
         end
 
         def build_data_logger
-          tagged = Legion::Logging::Logger.new(lex: 'data')
+          tagged = if defined?(Legion::Logging::TaggedLogger) && respond_to?(:tagged_logger_settings, true)
+                     Legion::Logging::TaggedLogger.new(
+                       segments: %w[data connection],
+                       **send(:tagged_logger_settings)
+                     )
+                   else
+                     SegmentedTaggedLogger.new(segments: %w[data connection])
+                   end
           SlowQueryLogger.new(tagged)
+        rescue StandardError => e
+          if respond_to?(:handle_exception, true)
+            handle_exception(e, level: :warn, handled: true, operation: :build_data_logger)
+          else
+            log.warn("build_data_logger failed: #{e.class}: #{e.message}")
+          end
+          SlowQueryLogger.new(SegmentedTaggedLogger.new(segments: %w[data connection], logger: log))
         end
       end
     end

--- a/lib/legion/data/connection.rb
+++ b/lib/legion/data/connection.rb
@@ -159,7 +159,7 @@ module Legion
                       ::Sequel.connect(opts.merge(adapter: :sqlite, database: sqlite_path))
                     else
                       begin
-                        ::Sequel.connect(opts.merge(adapter: adapter, **creds_builder))
+                        ::Sequel.connect(connection_opts_for(adapter: adapter, opts: opts))
                       rescue StandardError => e
                         raise unless dev_fallback?
 
@@ -331,6 +331,12 @@ module Legion
 
         def sqlite_path
           Legion::Settings[:data][:creds][:database] || 'legionio.db'
+        end
+
+        def connection_opts_for(adapter:, opts:)
+          connection_opts = opts.merge(adapter: adapter, **creds_builder)
+          connection_opts[:preconnect] = false if adapter != :sqlite && dev_fallback?
+          connection_opts
         end
 
         def sequel_opts

--- a/lib/legion/data/connection.rb
+++ b/lib/legion/data/connection.rb
@@ -154,7 +154,7 @@ module Legion
 
         def setup
           opts = sequel_opts
-          log.info { "Legion::Data::Connection setup adapter=#{adapter}" }
+          log.info("Legion::Data::Connection setup adapter=#{adapter}")
           @sequel = if adapter == :sqlite
                       ::Sequel.connect(opts.merge(adapter: :sqlite, database: sqlite_path))
                     else

--- a/lib/legion/data/encryption/key_provider.rb
+++ b/lib/legion/data/encryption/key_provider.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 
+require 'legion/logging/helper'
 require 'openssl'
 
 module Legion
   module Data
     module Encryption
       class KeyProvider
+        include Legion::Logging::Helper
+
         def initialize(mode: :auto)
           @mode = mode
           @key_cache = {}
@@ -18,20 +21,24 @@ module Legion
 
         def clear_cache!
           @key_cache.clear
+          log.debug 'Cleared encryption key cache'
         end
 
         private
 
         def derive_key(tenant_id)
           if tenant_id && crypt_available?
-            Legion::Logging.debug "Deriving Vault key for tenant #{tenant_id}" if defined?(Legion::Logging)
+            log.debug "Deriving Vault key for tenant #{tenant_id}"
             Legion::Crypt::PartitionKeys.derive(tenant_id: tenant_id)
           elsif crypt_available?
             Legion::Crypt.default_encryption_key
           else
-            Legion::Logging.warn 'Legion::Crypt unavailable, falling back to dev encryption key' if defined?(Legion::Logging)
+            log.warn 'Legion::Crypt unavailable, falling back to dev encryption key'
             local_key
           end
+        rescue StandardError => e
+          handle_exception(e, level: :error, handled: false, operation: :derive_key, tenant_id: tenant_id)
+          raise
         end
 
         def crypt_available?

--- a/lib/legion/data/encryption/sequel_plugin.rb
+++ b/lib/legion/data/encryption/sequel_plugin.rb
@@ -10,6 +10,31 @@ module Legion
       module SequelPlugin
         extend Legion::Logging::Helper
 
+        class << self
+          def aad_for(table_name:, primary_key:, column:)
+            "#{table_name}:#{primary_key || 0}:#{column}"
+          end
+
+          def decrypt_value(blob:, key:, table_name:, primary_key:, column:)
+            errors = []
+
+            aad_candidates(primary_key).each do |aad_primary_key|
+              aad = aad_for(table_name: table_name, primary_key: aad_primary_key, column: column)
+              return Legion::Data::Encryption::Cipher.decrypt(blob, key: key, aad: aad)
+            rescue OpenSSL::Cipher::CipherError, ArgumentError => e
+              errors << e
+            end
+
+            raise errors.last if errors.any?
+          end
+
+          private
+
+          def aad_candidates(primary_key)
+            [primary_key, 0].compact.uniq
+          end
+        end
+
         module ClassMethods
           def encrypted_columns
             @encrypted_columns ||= {}
@@ -23,12 +48,8 @@ module Legion
               raw = super()
               return nil if raw.nil?
 
-              provider = self.class.encryption_key_provider
-              tenant = col_scope == :tenant ? self[:tenant_id] : nil
-              key = provider.key_for(tenant_id: tenant)
-              aad = "#{self.class.table_name}:#{pk}:#{name}"
               begin
-                Legion::Data::Encryption::Cipher.decrypt(raw.b, key: key, aad: aad)
+                decrypt_encrypted_column(name, raw, key_scope: col_scope)
               rescue StandardError => e
                 Legion::Data::Encryption::SequelPlugin.handle_exception(
                   e,
@@ -45,15 +66,12 @@ module Legion
 
             define_method(:"#{name}=") do |value|
               if value.nil?
+                clear_pending_encrypted_column(name)
                 super(nil)
               else
                 begin
-                  provider = self.class.encryption_key_provider
-                  tenant = col_scope == :tenant ? self[:tenant_id] : nil
-                  key = provider.key_for(tenant_id: tenant)
-                  aad = "#{self.class.table_name}:#{pk || 0}:#{name}"
-                  encrypted = Legion::Data::Encryption::Cipher.encrypt(value.to_s, key: key, aad: aad)
-                  super(Sequel.blob(encrypted))
+                  remember_pending_encrypted_column(name, value, key_scope: col_scope) if new?
+                  super(encrypt_encrypted_column(name, value, key_scope: col_scope, primary_key: pk || 0))
                 rescue StandardError => e
                   Legion::Data::Encryption::SequelPlugin.handle_exception(
                     e,
@@ -76,6 +94,78 @@ module Legion
         end
 
         module InstanceMethods
+          def after_create
+            super
+            reencrypt_pending_encrypted_columns
+          end
+
+          private
+
+          def decrypt_encrypted_column(column, raw, key_scope:)
+            provider = self.class.encryption_key_provider
+            tenant = key_scope == :tenant ? self[:tenant_id] : nil
+            key = provider.key_for(tenant_id: tenant)
+
+            Legion::Data::Encryption::SequelPlugin.decrypt_value(
+              blob:        raw.b,
+              key:         key,
+              table_name:  self.class.table_name,
+              primary_key: pk,
+              column:      column
+            )
+          end
+
+          def encrypt_encrypted_column(column, value, key_scope:, primary_key:)
+            provider = self.class.encryption_key_provider
+            tenant = key_scope == :tenant ? self[:tenant_id] : nil
+            key = provider.key_for(tenant_id: tenant)
+            aad = Legion::Data::Encryption::SequelPlugin.aad_for(
+              table_name:  self.class.table_name,
+              primary_key: primary_key,
+              column:      column
+            )
+            encrypted = Legion::Data::Encryption::Cipher.encrypt(value.to_s, key: key, aad: aad)
+            Sequel.blob(encrypted)
+          end
+
+          def pending_encrypted_columns
+            @pending_encrypted_columns ||= {}
+          end
+
+          def remember_pending_encrypted_column(column, value, key_scope:)
+            pending_encrypted_columns[column] = { key_scope: key_scope, value: value.to_s }
+          end
+
+          def clear_pending_encrypted_column(column)
+            pending_encrypted_columns.delete(column) if defined?(@pending_encrypted_columns)
+          end
+
+          def reencrypt_pending_encrypted_columns
+            return if pending_encrypted_columns.empty?
+
+            encrypted_values = pending_encrypted_columns.each_with_object({}) do |(column, config), updates|
+              updates[column] = encrypt_encrypted_column(
+                column,
+                config[:value],
+                key_scope:   config[:key_scope],
+                primary_key: pk
+              )
+            end
+
+            self.class.where(pk_hash).update(encrypted_values)
+            encrypted_values.each { |column, encrypted| values[column] = encrypted }
+            pending_encrypted_columns.clear
+          rescue StandardError => e
+            Legion::Data::Encryption::SequelPlugin.handle_exception(
+              e,
+              level:       :error,
+              handled:     false,
+              operation:   :reencrypt_pending_columns,
+              table:       self.class.table_name,
+              primary_key: pk
+            )
+            raise
+          end
         end
       end
     end

--- a/lib/legion/data/encryption/sequel_plugin.rb
+++ b/lib/legion/data/encryption/sequel_plugin.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'legion/logging/helper'
 require_relative 'cipher'
 require_relative 'key_provider'
 
@@ -7,6 +8,8 @@ module Legion
   module Data
     module Encryption
       module SequelPlugin
+        extend Legion::Logging::Helper
+
         module ClassMethods
           def encrypted_columns
             @encrypted_columns ||= {}
@@ -27,7 +30,15 @@ module Legion
               begin
                 Legion::Data::Encryption::Cipher.decrypt(raw.b, key: key, aad: aad)
               rescue StandardError => e
-                Legion::Logging.warn "Decrypt failed for #{self.class.table_name}##{pk} column #{name}: #{e.message}" if defined?(Legion::Logging)
+                Legion::Data::Encryption::SequelPlugin.handle_exception(
+                  e,
+                  level:       :warn,
+                  handled:     false,
+                  operation:   :decrypt_column,
+                  table:       self.class.table_name,
+                  primary_key: pk,
+                  column:      name
+                )
                 raise
               end
             end
@@ -36,12 +47,25 @@ module Legion
               if value.nil?
                 super(nil)
               else
-                provider = self.class.encryption_key_provider
-                tenant = col_scope == :tenant ? self[:tenant_id] : nil
-                key = provider.key_for(tenant_id: tenant)
-                aad = "#{self.class.table_name}:#{pk || 0}:#{name}"
-                encrypted = Legion::Data::Encryption::Cipher.encrypt(value.to_s, key: key, aad: aad)
-                super(Sequel.blob(encrypted))
+                begin
+                  provider = self.class.encryption_key_provider
+                  tenant = col_scope == :tenant ? self[:tenant_id] : nil
+                  key = provider.key_for(tenant_id: tenant)
+                  aad = "#{self.class.table_name}:#{pk || 0}:#{name}"
+                  encrypted = Legion::Data::Encryption::Cipher.encrypt(value.to_s, key: key, aad: aad)
+                  super(Sequel.blob(encrypted))
+                rescue StandardError => e
+                  Legion::Data::Encryption::SequelPlugin.handle_exception(
+                    e,
+                    level:       :error,
+                    handled:     false,
+                    operation:   :encrypt_column,
+                    table:       self.class.table_name,
+                    primary_key: pk,
+                    column:      name
+                  )
+                  raise
+                end
               end
             end
           end

--- a/lib/legion/data/event_store.rb
+++ b/lib/legion/data/event_store.rb
@@ -32,7 +32,7 @@ module Legion
 
             data_json = Legion::JSON.dump(data)
             metadata_json = Legion::JSON.dump(metadata)
-            event_hash = compute_hash(stream, seq, type, data_json, prev_hash)
+            event_hash = compute_hash(stream, seq, type, data_json, metadata_json, prev_hash)
 
             conn[:governance_events].insert(
               stream_id:       stream,
@@ -75,9 +75,12 @@ module Legion
                                .all
 
           prev_hash = '0' * 64
+          legacy_hashes = 0
           events.each do |e|
-            expected = compute_hash(stream, e[:sequence_number], e[:event_type], e[:data_json], prev_hash)
-            unless e[:event_hash] == expected
+            expected = compute_hash(stream, e[:sequence_number], e[:event_type], e[:data_json], e[:metadata_json], prev_hash)
+            legacy_expected = legacy_compute_hash(stream, e[:sequence_number], e[:event_type], e[:data_json], prev_hash)
+
+            unless [expected, legacy_expected].include?(e[:event_hash])
               log.warn "EventStore chain broken: stream=#{stream} seq=#{e[:sequence_number]}"
               return { valid: false, broken_at: e[:sequence_number] }
             end
@@ -86,16 +89,29 @@ module Legion
               return { valid: false, broken_at: e[:sequence_number] }
             end
 
+            legacy_hashes += 1 if e[:event_hash] == legacy_expected && e[:event_hash] != expected
             prev_hash = e[:event_hash]
           end
 
-          { valid: true, length: events.size }
+          result = { valid: true, length: events.size }
+          result[:legacy_hashes] = legacy_hashes if legacy_hashes.positive?
+          result
         end
 
         private
 
-        def compute_hash(stream, seq, type, data_json, prev_hash)
-          Digest::SHA256.hexdigest("#{stream}:#{seq}:#{type}:#{data_json}:#{prev_hash}")
+        def compute_hash(stream, seq, type, data_json, metadata_json, prev_hash)
+          Digest::SHA256.hexdigest(
+            "#{stream}:#{seq}:#{type}:#{normalized_json(data_json)}:#{normalized_json(metadata_json)}:#{prev_hash}"
+          )
+        end
+
+        def legacy_compute_hash(stream, seq, type, data_json, prev_hash)
+          Digest::SHA256.hexdigest("#{stream}:#{seq}:#{type}:#{normalized_json(data_json)}:#{prev_hash}")
+        end
+
+        def normalized_json(json)
+          json || '{}'
         end
 
         def deserialize(event)

--- a/lib/legion/data/event_store.rb
+++ b/lib/legion/data/event_store.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'legion/logging/helper'
 require 'digest'
 
 module Legion
@@ -14,6 +15,8 @@ module Legion
       ].freeze
 
       class << self
+        include Legion::Logging::Helper
+
         def append(stream:, type:, data: {}, metadata: {})
           return { error: 'db unavailable' } unless db_ready?
 
@@ -42,7 +45,7 @@ module Legion
               created_at:      Time.now
             )
 
-            Legion::Logging.debug "EventStore append: stream=#{stream} type=#{type} seq=#{seq}" if defined?(Legion::Logging)
+            log.debug "EventStore append: stream=#{stream} type=#{type} seq=#{seq}"
             { stream: stream, sequence: seq, hash: event_hash }
           end
         end
@@ -75,11 +78,11 @@ module Legion
           events.each do |e|
             expected = compute_hash(stream, e[:sequence_number], e[:event_type], e[:data_json], prev_hash)
             unless e[:event_hash] == expected
-              Legion::Logging.warn "EventStore chain broken: stream=#{stream} seq=#{e[:sequence_number]}" if defined?(Legion::Logging)
+              log.warn "EventStore chain broken: stream=#{stream} seq=#{e[:sequence_number]}"
               return { valid: false, broken_at: e[:sequence_number] }
             end
             unless e[:previous_hash] == prev_hash
-              Legion::Logging.warn "EventStore chain broken: stream=#{stream} seq=#{e[:sequence_number]}" if defined?(Legion::Logging)
+              log.warn "EventStore chain broken: stream=#{stream} seq=#{e[:sequence_number]}"
               return { valid: false, broken_at: e[:sequence_number] }
             end
 
@@ -111,7 +114,7 @@ module Legion
         def db_ready?
           defined?(Legion::Data) && Legion::Data.connection&.table_exists?(:governance_events)
         rescue StandardError => e
-          Legion::Logging.debug("EventStore#db_ready? check failed: #{e.message}") if defined?(Legion::Logging)
+          handle_exception(e, level: :warn, handled: true, operation: :event_store_db_ready?)
           false
         end
       end

--- a/lib/legion/data/extract.rb
+++ b/lib/legion/data/extract.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'legion/logging/helper'
 require_relative 'extract/type_detector'
 require_relative 'extract/handlers/base'
 
@@ -7,6 +8,8 @@ module Legion
   module Data
     module Extract
       class << self
+        include Legion::Logging::Helper
+
         def extract(source, type: :auto)
           detected_type = type == :auto ? TypeDetector.detect(source) : type&.to_sym
           return { success: false, text: nil, error: :unknown_type } unless detected_type
@@ -19,13 +22,17 @@ module Legion
                      gem: handler.gem_name, type: detected_type }
           end
 
+          log.info "Extract starting type=#{detected_type} handler=#{handler.name}"
           result = handler.extract(source)
           if result[:text]
+            log.info "Extract succeeded type=#{detected_type}"
             { success: true, text: result[:text], metadata: result[:metadata], type: detected_type }
           else
+            log.warn "Extract failed type=#{detected_type} error=#{result[:error]}"
             { success: false, text: nil, error: result[:error], type: detected_type }
           end
         rescue StandardError => e
+          handle_exception(e, level: :error, handled: true, operation: :extract, type: detected_type)
           { success: false, text: nil, error: e.message, type: detected_type }
         end
 

--- a/lib/legion/data/extract/handlers/base.rb
+++ b/lib/legion/data/extract/handlers/base.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'legion/logging/helper'
+
 module Legion
   module Data
     module Extract
@@ -8,6 +10,8 @@ module Legion
           @registry = {}.freeze
 
           class << self
+            include Legion::Logging::Helper
+
             attr_reader :registry
 
             def inherited(subclass)
@@ -22,6 +26,7 @@ module Legion
             end
 
             def register(handler_class)
+              log.debug "Registered extract handler type=#{handler_class.type} class=#{handler_class.name}"
               @registry = @registry.merge(handler_class.type => handler_class).freeze
             end
 
@@ -47,7 +52,8 @@ module Legion
 
               require gem_name
               true
-            rescue LoadError
+            rescue LoadError => e
+              handle_exception(e, level: :debug, handled: true, operation: :extract_handler_available, handler: name, gem: gem_name)
               false
             end
           end

--- a/lib/legion/data/extract/handlers/csv.rb
+++ b/lib/legion/data/extract/handlers/csv.rb
@@ -17,6 +17,7 @@ module Legion
             text = table.map { |row| row.to_h.map { |k, v| "#{k}: #{v}" }.join(', ') }.join("\n")
             { text: text, metadata: { rows: table.size, columns: table.headers.size, headers: table.headers } }
           rescue StandardError => e
+            handle_exception(e, level: :warn, handled: true, operation: :extract_csv)
             { text: nil, error: e.message }
           end
         end

--- a/lib/legion/data/extract/handlers/docx.rb
+++ b/lib/legion/data/extract/handlers/docx.rb
@@ -16,9 +16,11 @@ module Legion
             paragraphs = doc.paragraphs.map(&:text).reject(&:empty?)
             text = paragraphs.join("\n\n")
             { text: text, metadata: { paragraphs: paragraphs.size } }
-          rescue LoadError
+          rescue LoadError => e
+            handle_exception(e, level: :warn, handled: true, operation: :extract_docx, gem: gem_name)
             { text: nil, error: :gem_not_installed, gem: gem_name }
           rescue StandardError => e
+            handle_exception(e, level: :warn, handled: true, operation: :extract_docx)
             { text: nil, error: e.message }
           end
         end

--- a/lib/legion/data/extract/handlers/html.rb
+++ b/lib/legion/data/extract/handlers/html.rb
@@ -21,9 +21,11 @@ module Legion
             title = doc.at_css('title')&.text&.strip
             text = doc.text.gsub(/\s+/, ' ').strip
             { text: text, metadata: { title: title } }
-          rescue LoadError
+          rescue LoadError => e
+            handle_exception(e, level: :warn, handled: true, operation: :extract_html, gem: gem_name)
             { text: nil, error: :gem_not_installed, gem: gem_name }
           rescue StandardError => e
+            handle_exception(e, level: :warn, handled: true, operation: :extract_html)
             { text: nil, error: e.message }
           end
         end

--- a/lib/legion/data/extract/handlers/json.rb
+++ b/lib/legion/data/extract/handlers/json.rb
@@ -17,6 +17,7 @@ module Legion
             text = ::JSON.pretty_generate(parsed)
             { text: text, metadata: { keys: parsed.is_a?(Hash) ? parsed.keys : nil } }
           rescue StandardError => e
+            handle_exception(e, level: :warn, handled: true, operation: :extract_json)
             { text: nil, error: e.message }
           end
         end

--- a/lib/legion/data/extract/handlers/jsonl.rb
+++ b/lib/legion/data/extract/handlers/jsonl.rb
@@ -17,6 +17,7 @@ module Legion
             text = lines.map { |l| l.is_a?(Hash) ? ::JSON.pretty_generate(l) : l }.join("\n---\n")
             { text: text, metadata: { lines: lines.size } }
           rescue StandardError => e
+            handle_exception(e, level: :warn, handled: true, operation: :extract_jsonl)
             { text: nil, error: e.message }
           end
         end

--- a/lib/legion/data/extract/handlers/markdown.rb
+++ b/lib/legion/data/extract/handlers/markdown.rb
@@ -15,6 +15,7 @@ module Legion
             text = content.sub(/\A---\n.*?\n---\n/m, '')
             { text: text.strip, metadata: { bytes: content.bytesize, has_frontmatter: content != text } }
           rescue StandardError => e
+            handle_exception(e, level: :warn, handled: true, operation: :extract_markdown)
             { text: nil, error: e.message }
           end
         end

--- a/lib/legion/data/extract/handlers/pdf.rb
+++ b/lib/legion/data/extract/handlers/pdf.rb
@@ -15,9 +15,11 @@ module Legion
             reader = ::PDF::Reader.new(source)
             text = reader.pages.map(&:text).join("\n\n")
             { text: text, metadata: { pages: reader.page_count, title: reader.info[:Title] } }
-          rescue LoadError
+          rescue LoadError => e
+            handle_exception(e, level: :warn, handled: true, operation: :extract_pdf, gem: gem_name)
             { text: nil, error: :gem_not_installed, gem: gem_name }
           rescue StandardError => e
+            handle_exception(e, level: :warn, handled: true, operation: :extract_pdf)
             { text: nil, error: e.message }
           end
         end

--- a/lib/legion/data/extract/handlers/pptx.rb
+++ b/lib/legion/data/extract/handlers/pptx.rb
@@ -24,9 +24,11 @@ module Legion
             end
             text = slides.each_with_index.map { |s, i| "Slide #{i + 1}: #{s}" }.join("\n\n")
             { text: text, metadata: { slides: slides.size } }
-          rescue LoadError
+          rescue LoadError => e
+            handle_exception(e, level: :warn, handled: true, operation: :extract_pptx, gem: gem_name)
             { text: nil, error: :gem_not_installed, gem: 'rubyzip' }
           rescue StandardError => e
+            handle_exception(e, level: :warn, handled: true, operation: :extract_pptx)
             { text: nil, error: e.message }
           end
         end

--- a/lib/legion/data/extract/handlers/text.rb
+++ b/lib/legion/data/extract/handlers/text.rb
@@ -13,6 +13,7 @@ module Legion
             content = source.respond_to?(:read) ? source.read : File.read(source.to_s)
             { text: content, metadata: { bytes: content.bytesize } }
           rescue StandardError => e
+            handle_exception(e, level: :warn, handled: true, operation: :extract_text)
             { text: nil, error: e.message }
           end
         end

--- a/lib/legion/data/extract/handlers/vtt.rb
+++ b/lib/legion/data/extract/handlers/vtt.rb
@@ -32,6 +32,7 @@ module Legion
               }
             }
           rescue StandardError => e
+            handle_exception(e, level: :warn, handled: true, operation: :extract_vtt)
             { text: nil, error: e.message }
           end
 

--- a/lib/legion/data/extract/handlers/xlsx.rb
+++ b/lib/legion/data/extract/handlers/xlsx.rb
@@ -25,9 +25,11 @@ module Legion
             end
             text = sheets.join("\n\n")
             { text: text, metadata: { sheets: workbook.worksheets.size } }
-          rescue LoadError
+          rescue LoadError => e
+            handle_exception(e, level: :warn, handled: true, operation: :extract_xlsx, gem: gem_name)
             { text: nil, error: :gem_not_installed, gem: gem_name }
           rescue StandardError => e
+            handle_exception(e, level: :warn, handled: true, operation: :extract_xlsx)
             { text: nil, error: e.message }
           end
         end

--- a/lib/legion/data/helper.rb
+++ b/lib/legion/data/helper.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
+require 'legion/logging/helper'
+
 module Legion
   module Data
     module Helper
+      include Legion::Logging::Helper
+
       def data_path
         @data_path ||= "#{full_path}/data"
       end
@@ -39,7 +43,8 @@ module Legion
 
       def data_adapter
         Legion::Data::Connection.adapter
-      rescue StandardError
+      rescue StandardError => e
+        handle_exception(e, level: :warn, handled: true, operation: :data_adapter)
         :unknown
       end
 
@@ -47,7 +52,8 @@ module Legion
         return {} unless data_connected?
 
         Legion::Data::Connection.pool_stats
-      rescue StandardError
+      rescue StandardError => e
+        handle_exception(e, level: :warn, handled: true, operation: :data_pool_stats)
         {}
       end
 
@@ -55,7 +61,8 @@ module Legion
         return {} unless data_connected?
 
         Legion::Data.stats
-      rescue StandardError
+      rescue StandardError => e
+        handle_exception(e, level: :warn, handled: true, operation: :data_stats)
         {}
       end
 
@@ -63,7 +70,8 @@ module Legion
         return {} unless local_data_connected?
 
         Legion::Data::Local.stats
-      rescue StandardError
+      rescue StandardError => e
+        handle_exception(e, level: :warn, handled: true, operation: :local_data_stats)
         {}
       end
 
@@ -71,13 +79,15 @@ module Legion
 
       def data_can_read?(table_name)
         Legion::Data.can_read?(table_name)
-      rescue StandardError
+      rescue StandardError => e
+        handle_exception(e, level: :warn, handled: true, operation: :data_can_read, table: table_name)
         false
       end
 
       def data_can_write?(table_name)
         Legion::Data.can_write?(table_name)
-      rescue StandardError
+      rescue StandardError => e
+        handle_exception(e, level: :warn, handled: true, operation: :data_can_write, table: table_name)
         false
       end
     end

--- a/lib/legion/data/local.rb
+++ b/lib/legion/data/local.rb
@@ -27,17 +27,18 @@ module Legion
             opts[key] = val unless val.nil?
           end
 
-          opts[:logger] = build_local_logger
-          opts[:sql_log_level] = resolved_sql_log_level
-          opts[:log_warn_duration] = resolved_log_warn_duration
-
           if local_settings[:query_log]
             log_path = File.join(Legion::Data::Connection::QUERY_LOG_DIR, 'data-local-query.log')
             @query_file_logger = Legion::Data::Connection::QueryFileLogger.new(log_path)
+            opts[:logger]          = @query_file_logger
+            opts[:sql_log_level]   = :debug
+          elsif data[:log] && defined?(Legion::Logging)
+            opts[:logger]          = build_local_logger
+            opts[:sql_log_level]   = resolved_sql_log_level
+            opts[:log_warn_duration] = resolved_log_warn_duration
           end
 
           @connection = ::Sequel.connect(opts)
-          @connection.loggers << @query_file_logger if @query_file_logger
           @connected = true
           run_migrations
           log.info "Legion::Data::Local connected to #{db_file}"

--- a/lib/legion/data/local.rb
+++ b/lib/legion/data/local.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'legion/logging/helper'
+
 require 'sequel'
 require 'sequel/extensions/migration'
 
@@ -7,6 +9,8 @@ module Legion
   module Data
     module Local
       class << self
+        include Legion::Logging::Helper
+
         attr_reader :connection, :db_path
 
         def setup(database: nil, **)
@@ -23,17 +27,23 @@ module Legion
             opts[key] = val unless val.nil?
           end
 
+          opts[:logger] = build_local_logger
+          opts[:sql_log_level] = resolved_sql_log_level
+          opts[:log_warn_duration] = resolved_log_warn_duration
+
           if local_settings[:query_log]
             log_path = File.join(Legion::Data::Connection::QUERY_LOG_DIR, 'data-local-query.log')
             @query_file_logger = Legion::Data::Connection::QueryFileLogger.new(log_path)
-            opts[:logger]        = @query_file_logger
-            opts[:sql_log_level] = :debug
           end
 
           @connection = ::Sequel.connect(opts)
+          @connection.loggers << @query_file_logger if @query_file_logger
           @connected = true
           run_migrations
-          Legion::Logging.info "Legion::Data::Local connected to #{db_file}" if defined?(Legion::Logging)
+          log.info "Legion::Data::Local connected to #{db_file}"
+        rescue StandardError => e
+          handle_exception(e, level: :error, handled: false, operation: :local_setup, database: db_file)
+          raise
         end
 
         def shutdown
@@ -82,7 +92,8 @@ module Legion
              wal_autocheckpoint cache_size busy_timeout].each do |pragma|
             val = begin
               @connection.fetch("PRAGMA #{pragma}").single_value
-            rescue StandardError
+            rescue StandardError => e
+              handle_exception(e, level: :warn, handled: true, operation: :local_stats_pragma, pragma: pragma)
               nil
             end
             stats[pragma.to_sym] = val unless val.nil?
@@ -92,6 +103,7 @@ module Legion
 
           stats
         rescue StandardError => e
+          handle_exception(e, level: :warn, handled: true, operation: :local_stats, database: @db_path)
           { connected: connected?, error: e.message }
         end
 
@@ -119,13 +131,48 @@ module Legion
           table = :"schema_migrations_#{name}"
           ::Sequel::TimestampMigrator.new(@connection, path, table: table).run
         rescue StandardError => e
-          Legion::Logging.warn "Local migration failed for #{path}: #{e.message}" if defined?(Legion::Logging)
+          handle_exception(e, level: :warn, handled: true, operation: :local_migration, name: name, path: path)
         end
 
         def local_settings
           return {} unless defined?(Legion::Settings)
 
           Legion::Settings[:data]&.dig(:local) || {}
+        end
+
+        def build_local_logger
+          tagged = if defined?(Legion::Logging::TaggedLogger) && respond_to?(:tagged_logger_settings, true)
+                     Legion::Logging::TaggedLogger.new(
+                       segments: %w[data local],
+                       **send(:tagged_logger_settings)
+                     )
+                   else
+                     Legion::Data::Connection::SegmentedTaggedLogger.new(segments: %w[data local])
+                   end
+          Legion::Data::Connection::SlowQueryLogger.new(tagged)
+        rescue StandardError => e
+          if respond_to?(:handle_exception, true)
+            handle_exception(e, level: :warn, handled: true, operation: :build_local_logger)
+          else
+            log.warn("build_local_logger failed: #{e.class}: #{e.message}")
+          end
+          Legion::Data::Connection::SlowQueryLogger.new(
+            Legion::Data::Connection::SegmentedTaggedLogger.new(segments: %w[data local], logger: log)
+          )
+        end
+
+        def resolved_sql_log_level
+          (local_settings[:sql_log_level] || Legion::Settings[:data][:sql_log_level] || 'debug').to_sym
+        rescue StandardError => e
+          handle_exception(e, level: :warn, handled: true, operation: :resolved_sql_log_level)
+          :debug
+        end
+
+        def resolved_log_warn_duration
+          local_settings[:log_warn_duration] || Legion::Settings[:data][:log_warn_duration]
+        rescue StandardError => e
+          handle_exception(e, level: :warn, handled: true, operation: :resolved_log_warn_duration)
+          nil
         end
       end
     end

--- a/lib/legion/data/migration.rb
+++ b/lib/legion/data/migration.rb
@@ -1,16 +1,21 @@
 # frozen_string_literal: true
 
+require 'legion/logging/helper'
+
 require 'sequel/extensions/migration'
 
 module Legion
   module Data
     module Migration
       class << self
+        include Legion::Logging::Helper
+
         def migrate(connection = Legion::Data.connection, path = "#{__dir__}/migrations", **)
           Legion::Settings[:data][:migrations][:version] = Sequel::Migrator.run(connection, path, **)
-          Legion::Logging.info("Legion::Data::Migration ran successfully to version #{Legion::Settings[:data][:migrations][:version]}")
+          log.info("Legion::Data::Migration ran successfully to version #{Legion::Settings[:data][:migrations][:version]}")
           Legion::Settings[:data][:migrations][:ran] = true
         rescue Sequel::DatabaseError => e
+          handle_exception(e, level: :error, handled: false, operation: :migrate, path: path)
           if e.message.include?('InsufficientPrivilege') || e.message.include?('permission denied')
             raise Sequel::DatabaseError,
                   "#{e.message}\n  Hint: the database user lacks CREATE on schema public " \

--- a/lib/legion/data/migrations/044_expand_memory_traces.rb
+++ b/lib/legion/data/migrations/044_expand_memory_traces.rb
@@ -29,7 +29,10 @@ Sequel.migration do
 
     indexes = begin
       db.indexes(:memory_traces).keys
-    rescue StandardError
+    rescue StandardError => e
+      if defined?(Legion::Data) && Legion::Data.respond_to?(:handle_exception)
+        Legion::Data.handle_exception(e, level: :warn, handled: true, operation: :migration_044_indexes)
+      end
       []
     end
 

--- a/lib/legion/data/model.rb
+++ b/lib/legion/data/model.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
+require 'legion/logging/helper'
+
 module Legion
   module Data
     module Models
       class << self
+        include Legion::Logging::Helper
+
         attr_reader :loaded_models
 
         def models
@@ -13,7 +17,7 @@ module Legion
         end
 
         def load
-          Legion::Logging.info 'Loading Legion::Data::Models'
+          log.info 'Loading Legion::Data::Models'
           @loaded_models ||= []
           require_sequel_models(models)
           Legion::Settings[:data][:models][:loaded] = true
@@ -25,13 +29,13 @@ module Legion
         end
 
         def load_sequel_model(model)
-          Legion::Logging.debug("Trying to load #{model}.rb")
+          log.debug("Trying to load #{model}.rb")
           require_relative "models/#{model}"
           @loaded_models << model
-          Legion::Logging.debug("Successfully loaded #{model}")
+          log.debug("Successfully loaded #{model}")
           model
         rescue LoadError => e
-          Legion::Logging.fatal("Failed to load #{model}")
+          handle_exception(e, level: :fatal, operation: :load_sequel_model, model: model)
           raise e unless Legion::Settings[:data][:models][:continue_on_fail]
         end
       end

--- a/lib/legion/data/models/audit_log.rb
+++ b/lib/legion/data/models/audit_log.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
+require 'legion/logging/helper'
+
 module Legion
   module Data
     module Model
       class AuditLog < Sequel::Model(:audit_log)
+        include Legion::Logging::Helper
+
         VALID_EVENT_TYPES = %w[runner_execution lifecycle_transition].freeze
         VALID_STATUSES    = %w[success failure denied].freeze
 
@@ -18,7 +22,7 @@ module Legion
 
           Legion::JSON.load(detail)
         rescue StandardError => e
-          Legion::Logging.warn("AuditLog#parsed_detail JSON parse failed: #{e.message}") if defined?(Legion::Logging)
+          handle_exception(e, level: :warn, handled: true, operation: :parsed_detail, id: self[:id])
           nil
         end
 

--- a/lib/legion/data/models/audit_record.rb
+++ b/lib/legion/data/models/audit_record.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
+require 'legion/logging/helper'
+
 module Legion
   module Data
     module Model
       class AuditRecord < Sequel::Model(:audit_records)
+        include Legion::Logging::Helper
+
         # Enforce append-only semantics at the application layer.
         # PostgreSQL enforces this at the DB layer via rules (migration 058);
         # the application guard covers SQLite and MySQL.
@@ -21,7 +25,7 @@ module Legion
 
           Legion::JSON.load(metadata)
         rescue StandardError => e
-          Legion::Logging.warn "AuditRecord#parsed_metadata failed: #{e.message}" if defined?(Legion::Logging)
+          handle_exception(e, level: :warn, handled: true, operation: :parsed_metadata, id: self[:id])
           {}
         end
       end

--- a/lib/legion/data/models/function.rb
+++ b/lib/legion/data/models/function.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
+require 'legion/logging/helper'
+
 module Legion
   module Data
     module Model
       class Function < Sequel::Model
+        include Legion::Logging::Helper
+
         many_to_one :runner
         one_to_many :trigger_relationships, class: 'Legion::Data::Model::Relationship', key: :trigger_id
         one_to_many :action_relationships, class: 'Legion::Data::Model::Relationship', key: :action_id
@@ -13,7 +17,7 @@ module Legion
 
           ::JSON.parse(embedding)
         rescue ::JSON::ParserError => e
-          Legion::Logging.debug("Function#embedding_vector JSON parse failed: #{e.message}") if defined?(Legion::Logging)
+          handle_exception(e, level: :debug, handled: true, operation: :embedding_vector, id: self[:id])
           nil
         end
 

--- a/lib/legion/data/models/node.rb
+++ b/lib/legion/data/models/node.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
+require 'legion/logging/helper'
+
 module Legion
   module Data
     module Model
       class Node < Sequel::Model
+        include Legion::Logging::Helper
+
         # one_to_many :task_log
 
         def parsed_metrics
@@ -11,7 +15,7 @@ module Legion
 
           Legion::JSON.load(metrics)
         rescue StandardError => e
-          Legion::Logging.debug("Node#parsed_metrics JSON parse failed: #{e.message}") if defined?(Legion::Logging)
+          handle_exception(e, level: :debug, handled: true, operation: :parsed_metrics, id: self[:id])
           nil
         end
 
@@ -20,7 +24,7 @@ module Legion
 
           Legion::JSON.load(hosted_worker_ids)
         rescue StandardError => e
-          Legion::Logging.debug("Node#parsed_hosted_worker_ids JSON parse failed: #{e.message}") if defined?(Legion::Logging)
+          handle_exception(e, level: :debug, handled: true, operation: :parsed_hosted_worker_ids, id: self[:id])
           []
         end
       end

--- a/lib/legion/data/partition_manager.rb
+++ b/lib/legion/data/partition_manager.rb
@@ -1,11 +1,15 @@
 # frozen_string_literal: true
 
+require 'legion/logging/helper'
+
 module Legion
   module Data
     module PartitionManager
       NOT_POSTGRES = { skipped: true, reason: 'not_postgres' }.freeze
 
       class << self
+        include Legion::Logging::Helper
+
         def ensure_partitions(table:, months_ahead: 3)
           return NOT_POSTGRES unless postgres?
 
@@ -28,16 +32,17 @@ module Legion
             after_count = partition_names_for(table).size
 
             if after_count > before_count
-              log_info("Created partition #{partition}") if logging?
+              log.info("Created partition #{partition}")
               created << partition
             else
               existing << partition
             end
           end
 
+          log.info "PartitionManager ensure_partitions table=#{table} created=#{created.size} existing=#{existing.size}"
           { created: created, existing: existing }
         rescue StandardError => e
-          log_warn("ensure_partitions failed for #{table}: #{e.message}") if logging?
+          handle_exception(e, level: :warn, handled: true, operation: :ensure_partitions, table: table, months_ahead: months_ahead)
           { created: [], existing: [], error: e.message }
         end
 
@@ -54,16 +59,17 @@ module Legion
 
             if part_date < cutoff
               Legion::Data.connection.run("DROP TABLE #{part}")
-              log_info("Dropped partition #{part}") if logging?
+              log.info("Dropped partition #{part}")
               dropped << part
             else
               retained << part
             end
           end
 
+          log.info "PartitionManager drop_old_partitions table=#{table} dropped=#{dropped.size} retained=#{retained.size}"
           { dropped: dropped, retained: retained }
         rescue StandardError => e
-          log_warn("drop_old_partitions failed for #{table}: #{e.message}") if logging?
+          handle_exception(e, level: :warn, handled: true, operation: :drop_old_partitions, table: table, retention_months: retention_months)
           { dropped: [], retained: [], error: e.message }
         end
 
@@ -80,12 +86,14 @@ module Legion
             ORDER  BY c.relname
           SQL
 
-          Legion::Data.connection.fetch(sql).map do |row|
+          partitions = Legion::Data.connection.fetch(sql).map do |row|
             from_val, to_val = parse_bound(row[:bound])
             { name: row[:name], from: from_val, to: to_val }
           end
+          log.info "PartitionManager list_partitions table=#{table} count=#{partitions.size}"
+          partitions
         rescue StandardError => e
-          log_warn("list_partitions failed for #{table}: #{e.message}") if logging?
+          handle_exception(e, level: :warn, handled: true, operation: :list_partitions, table: table)
           []
         end
 
@@ -93,18 +101,6 @@ module Legion
 
         def postgres?
           Legion::Data::Connection.adapter == :postgres
-        end
-
-        def logging?
-          defined?(Legion::Logging)
-        end
-
-        def log_info(msg)
-          Legion::Logging.info(msg)
-        end
-
-        def log_warn(msg)
-          Legion::Logging.warn(msg)
         end
 
         def partition_name(table, date)
@@ -136,7 +132,7 @@ module Legion
 
           Legion::Data.connection.fetch(sql).map { |row| row[:name] }
         rescue StandardError => e
-          log_warn("partition_names_for #{table} failed: #{e.message}") if logging?
+          handle_exception(e, level: :warn, handled: true, operation: :partition_names_for, table: table)
           []
         end
 

--- a/lib/legion/data/retention.rb
+++ b/lib/legion/data/retention.rb
@@ -93,7 +93,7 @@ module Legion
             oldest_archived: oldest_archived
           }
         rescue StandardError => e
-          handle_exception(e, level: :warn, handled: true, operation: :retention_status, table: table, date_column: date_column)
+          handle_exception(e, level: :warn, handled: false, operation: :retention_status, table: table, date_column: date_column)
           raise
         end
 

--- a/lib/legion/data/retention.rb
+++ b/lib/legion/data/retention.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'legion/logging/helper'
 require_relative 'archival/policy'
 
 module Legion
@@ -9,6 +10,8 @@ module Legion
       DEFAULT_ARCHIVE_AFTER_DAYS = 90
 
       class << self
+        include Legion::Logging::Helper
+
         def archive_old_records(table:, date_column: nil, archive_after_days: DEFAULT_ARCHIVE_AFTER_DAYS)
           db = Legion::Data.connection
           return { archived: 0, table: table } unless db
@@ -29,8 +32,19 @@ module Legion
             end
           end
 
-          Legion::Logging.info "Archived #{count} row(s) from #{table}" if defined?(Legion::Logging) && count.positive?
+          log.info "Archived #{count} row(s) from #{table}" if count.positive?
           { archived: count, table: table }
+        rescue StandardError => e
+          handle_exception(
+            e,
+            level:              :error,
+            handled:            false,
+            operation:          :archive_old_records,
+            table:              table,
+            date_column:        date_column,
+            archive_after_days: archive_after_days
+          )
+          raise
         end
 
         def purge_expired_records(table:, date_column: nil, retention_years: DEFAULT_RETENTION_YEARS)
@@ -43,9 +57,20 @@ module Legion
           expired = db[archive_table].where(Sequel.identifier(date_column) < cutoff)
           count = expired.count
           expired.delete if count.positive?
-          Legion::Logging.info "Purged #{count} expired row(s) from #{archive_table}" if defined?(Legion::Logging) && count.positive?
+          log.info "Purged #{count} expired row(s) from #{archive_table}" if count.positive?
 
           { purged: count, table: table }
+        rescue StandardError => e
+          handle_exception(
+            e,
+            level:           :error,
+            handled:         false,
+            operation:       :purge_expired_records,
+            table:           table,
+            date_column:     date_column,
+            retention_years: retention_years
+          )
+          raise
         end
 
         def retention_status(table:, date_column: nil)
@@ -67,6 +92,9 @@ module Legion
             oldest_active:   oldest_active,
             oldest_archived: oldest_archived
           }
+        rescue StandardError => e
+          handle_exception(e, level: :warn, handled: true, operation: :retention_status, table: table, date_column: date_column)
+          raise
         end
 
         def archive_table_name(table)
@@ -90,6 +118,7 @@ module Legion
 
           source_schema = db.schema(source_table).to_h
 
+          log.info "Creating archive table #{archive_table} from #{source_table}"
           db.create_table(archive_table) do
             source_schema.each do |col_name, col_info|
               column col_name, col_info[:db_type]

--- a/lib/legion/data/rls.rb
+++ b/lib/legion/data/rls.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
+require 'legion/logging/helper'
+
 module Legion
   module Data
     module Rls
+      extend Legion::Logging::Helper
+
       RLS_TABLES = %i[
         tasks digital_workers audit_log memory_traces extensions
         functions runners nodes settings value_metrics
@@ -14,7 +18,8 @@ module Legion
         return false unless Legion::Settings[:data][:connected]
 
         Legion::Data.connection.adapter_scheme == :postgres
-      rescue StandardError
+      rescue StandardError => e
+        handle_exception(e, level: :warn, handled: true, operation: :rls_enabled)
         false
       end
 
@@ -30,7 +35,8 @@ module Legion
         return nil unless rls_enabled?
 
         Legion::Data.connection.fetch('SHOW app.current_tenant').first&.values&.first
-      rescue Sequel::DatabaseError
+      rescue Sequel::DatabaseError => e
+        handle_exception(e, level: :warn, handled: true, operation: :current_tenant)
         nil
       end
 

--- a/lib/legion/data/settings.rb
+++ b/lib/legion/data/settings.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
+require 'legion/logging/helper'
+
 module Legion
   module Data
     module Settings
+      extend Legion::Logging::Helper
+
       CREDS = {
         sqlite:   {
           database: 'legionio.db'
@@ -130,5 +134,5 @@ end
 begin
   Legion::Settings.merge_settings('data', Legion::Data::Settings.default) if Legion.const_defined?('Settings', false)
 rescue StandardError => e
-  Legion::Logging.fatal(e.message) if Legion::Logging.method_defined?(:fatal)
+  Legion::Data::Settings.handle_exception(e, level: :fatal, operation: :merge_settings)
 end

--- a/lib/legion/data/spool.rb
+++ b/lib/legion/data/spool.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'legion/logging/helper'
 require 'json'
 require 'fileutils'
 require 'securerandom'
@@ -31,6 +32,8 @@ module Legion
       end
 
       class ScopedSpool
+        include Legion::Logging::Helper
+
         def initialize(extension_module, spool_root)
           @extension_dir = File.join(spool_root, Spool.send(:extension_path, extension_module))
         end
@@ -41,24 +44,34 @@ module Legion
           filename = "#{Time.now.strftime('%s%9N')}-#{SecureRandom.uuid}.json"
           path = File.join(dir, filename)
           File.write(path, ::JSON.generate(payload))
-          Legion::Logging.debug "Spool write: #{sub_namespace} -> #{filename}" if defined?(Legion::Logging)
+          log.info "Spool write: #{sub_namespace} -> #{filename}"
           path
+        rescue StandardError => e
+          handle_exception(e, level: :error, handled: false, operation: :spool_write, sub_namespace: sub_namespace)
+          raise
         end
 
         def read(sub_namespace)
           sorted_files(sub_namespace).map { |f| ::JSON.parse(File.read(f), symbolize_names: true) }
+        rescue StandardError => e
+          handle_exception(e, level: :error, handled: false, operation: :spool_read, sub_namespace: sub_namespace)
+          raise
         end
 
         def flush(sub_namespace)
           count = 0
+          path = nil
           sorted_files(sub_namespace).each do |path|
             event = ::JSON.parse(File.read(path), symbolize_names: true)
             yield event
             File.delete(path)
             count += 1
           end
-          Legion::Logging.info "Spool drained #{count} item(s) from #{sub_namespace}" if defined?(Legion::Logging) && count.positive?
+          log.info "Spool drained #{count} item(s) from #{sub_namespace}" if count.positive?
           count
+        rescue StandardError => e
+          handle_exception(e, level: :error, handled: false, operation: :spool_flush, sub_namespace: sub_namespace, path: path)
+          raise
         end
 
         def count(sub_namespace)
@@ -70,6 +83,10 @@ module Legion
           return unless Dir.exist?(dir)
 
           Dir[File.join(dir, '*.json')].each { |f| File.delete(f) }
+          log.info "Spool cleared #{sub_namespace}"
+        rescue StandardError => e
+          handle_exception(e, level: :error, handled: false, operation: :spool_clear, sub_namespace: sub_namespace)
+          raise
         end
 
         private

--- a/lib/legion/data/spool.rb
+++ b/lib/legion/data/spool.rb
@@ -43,16 +43,22 @@ module Legion
           FileUtils.mkdir_p(dir)
           filename = "#{Time.now.strftime('%s%9N')}-#{SecureRandom.uuid}.json"
           path = File.join(dir, filename)
-          File.write(path, ::JSON.generate(payload))
+          temp_path = temp_path_for(dir, filename)
+          File.binwrite(temp_path, ::JSON.generate(payload))
+          File.rename(temp_path, path)
           log.info "Spool write: #{sub_namespace} -> #{filename}"
           path
         rescue StandardError => e
+          File.delete(temp_path) if defined?(temp_path) && temp_path && File.exist?(temp_path)
           handle_exception(e, level: :error, handled: false, operation: :spool_write, sub_namespace: sub_namespace)
           raise
         end
 
         def read(sub_namespace)
-          sorted_files(sub_namespace).map { |f| ::JSON.parse(File.read(f), symbolize_names: true) }
+          sorted_files(sub_namespace).each_with_object([]) do |path, events|
+            event = load_event_file(path, sub_namespace)
+            events << event if event
+          end
         rescue StandardError => e
           handle_exception(e, level: :error, handled: false, operation: :spool_read, sub_namespace: sub_namespace)
           raise
@@ -62,7 +68,9 @@ module Legion
           count = 0
           path = nil
           sorted_files(sub_namespace).each do |path|
-            event = ::JSON.parse(File.read(path), symbolize_names: true)
+            event = load_event_file(path, sub_namespace)
+            next unless event
+
             yield event
             File.delete(path)
             count += 1
@@ -99,7 +107,45 @@ module Legion
           dir = sub_dir(sub_namespace)
           return [] unless Dir.exist?(dir)
 
-          Dir[File.join(dir, '*.json')]
+          Dir.glob(File.join(dir, '*.json'), sort: true)
+        end
+
+        def load_event_file(path, sub_namespace)
+          ::JSON.parse(File.binread(path), symbolize_names: true)
+        rescue Errno::ENOENT
+          nil
+        rescue ::JSON::ParserError, EOFError, ArgumentError => e
+          quarantine_corrupt_file(path, sub_namespace, e)
+          nil
+        end
+
+        def quarantine_corrupt_file(path, sub_namespace, error)
+          return unless File.exist?(path)
+
+          quarantine_dir = File.join(sub_dir(sub_namespace), 'quarantine')
+          FileUtils.mkdir_p(quarantine_dir)
+          quarantine_path = unique_quarantine_path(quarantine_dir, File.basename(path))
+          File.rename(path, quarantine_path)
+          handle_exception(
+            error,
+            level:           :warn,
+            handled:         true,
+            operation:       :spool_quarantine,
+            sub_namespace:   sub_namespace,
+            path:            path,
+            quarantine_path: quarantine_path
+          )
+        end
+
+        def unique_quarantine_path(quarantine_dir, basename)
+          path = File.join(quarantine_dir, "#{basename}.corrupt")
+          return path unless File.exist?(path)
+
+          File.join(quarantine_dir, "#{basename}.#{SecureRandom.uuid}.corrupt")
+        end
+
+        def temp_path_for(dir, filename)
+          File.join(dir, ".#{filename}.tmp-#{SecureRandom.uuid}")
         end
       end
     end

--- a/lib/legion/data/storage_tiers.rb
+++ b/lib/legion/data/storage_tiers.rb
@@ -1,11 +1,15 @@
 # frozen_string_literal: true
 
+require 'legion/logging/helper'
+
 module Legion
   module Data
     module StorageTiers
       TIERS = { hot: 0, warm: 1, cold: 2 }.freeze
 
       class << self
+        include Legion::Logging::Helper
+
         def archive_to_warm(table:, age_days: 90, batch_size: 1000)
           return { archived: 0, reason: 'no_connection' } unless Legion::Data.connection
           return { archived: 0, reason: 'no_archive_table' } unless Legion::Data.connection.table_exists?(:data_archive)
@@ -28,8 +32,11 @@ module Legion
             Legion::Data.connection[table].where(id: ids).delete
           end
 
-          Legion::Logging.info "Archived #{records.size} row(s) from #{table} to warm tier" if defined?(Legion::Logging)
+          log.info "Archived #{records.size} row(s) from #{table} to warm tier"
           { archived: records.size, table: table.to_s }
+        rescue StandardError => e
+          handle_exception(e, level: :error, handled: false, operation: :archive_to_warm, table: table, age_days: age_days, batch_size: batch_size)
+          raise
         end
 
         def export_to_cold(age_days: 365, batch_size: 5000)
@@ -44,14 +51,20 @@ module Legion
 
           ids = records.map { |r| r[:id] }
           Legion::Data.connection[:data_archive].where(id: ids).update(tier: TIERS[:cold])
-          Legion::Logging.info "Exported #{records.size} row(s) to cold tier" if defined?(Legion::Logging)
+          log.info "Exported #{records.size} row(s) to cold tier"
           { exported: records.size, data: records }
+        rescue StandardError => e
+          handle_exception(e, level: :error, handled: false, operation: :export_to_cold, age_days: age_days, batch_size: batch_size)
+          raise
         end
 
         def stats
           return {} unless Legion::Data.connection&.table_exists?(:data_archive)
 
           { warm: count_tier(:warm), cold: count_tier(:cold) }
+        rescue StandardError => e
+          handle_exception(e, level: :warn, handled: true, operation: :storage_tiers_stats)
+          {}
         end
 
         private
@@ -59,7 +72,7 @@ module Legion
         def count_tier(tier)
           Legion::Data.connection[:data_archive].where(tier: TIERS[tier]).count
         rescue StandardError => e
-          Legion::Logging.debug("StorageTiers#count_tier failed for #{tier}: #{e.message}") if defined?(Legion::Logging)
+          handle_exception(e, level: :warn, handled: true, operation: :storage_tiers_count, tier: tier)
           0
         end
       end

--- a/lib/legion/data/vector.rb
+++ b/lib/legion/data/vector.rb
@@ -1,16 +1,20 @@
 # frozen_string_literal: true
 
+require 'legion/logging/helper'
+
 module Legion
   module Data
     module Vector
       class << self
+        include Legion::Logging::Helper
+
         def available?
           return false unless Legion::Data.connection
           return false unless Legion::Data.connection.adapter_scheme == :postgres
 
           Legion::Data.connection.fetch("SELECT 1 FROM pg_extension WHERE extname = 'vector'").any?
         rescue StandardError => e
-          Legion::Logging.debug("Vector#available? check failed: #{e.message}") if defined?(Legion::Logging)
+          handle_exception(e, level: :warn, handled: true, operation: :vector_available?)
           false
         end
 
@@ -18,17 +22,17 @@ module Legion
           return false unless Legion::Data.connection&.adapter_scheme == :postgres
 
           Legion::Data.connection.run('CREATE EXTENSION IF NOT EXISTS vector')
-          Legion::Logging.info 'pgvector extension enabled' if defined?(Legion::Logging)
+          log.info 'pgvector extension enabled'
           true
         rescue StandardError => e
-          Legion::Logging.warn("pgvector extension creation failed: #{e.message}") if defined?(Legion::Logging)
+          handle_exception(e, level: :warn, handled: true, operation: :ensure_vector_extension)
           false
         end
 
         def cosine_search(table:, column:, query_vector:, limit: 10, min_similarity: 0.0)
           return [] unless available?
 
-          Legion::Logging.debug "Vector cosine_search: table=#{table} column=#{column} limit=#{limit}" if defined?(Legion::Logging)
+          log.debug "Vector cosine_search: table=#{table} column=#{column} limit=#{limit}"
           vec_literal = vector_literal(query_vector)
           ds = Legion::Data.connection[table]
                            .select_all
@@ -43,7 +47,7 @@ module Legion
         def l2_search(table:, column:, query_vector:, limit: 10)
           return [] unless available?
 
-          Legion::Logging.debug "Vector l2_search: table=#{table} column=#{column} limit=#{limit}" if defined?(Legion::Logging)
+          log.debug "Vector l2_search: table=#{table} column=#{column} limit=#{limit}"
           vec_literal = vector_literal(query_vector)
           Legion::Data.connection[table]
                       .select_all

--- a/lib/legion/data/version.rb
+++ b/lib/legion/data/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Data
-    VERSION = '1.6.18'
+    VERSION = '1.6.19'
   end
 end

--- a/spec/legion/data/connection_fallback_spec.rb
+++ b/spec/legion/data/connection_fallback_spec.rb
@@ -55,6 +55,21 @@ RSpec.describe Legion::Data::Connection do
         expect(described_class.adapter).to eq(:sqlite)
         expect(described_class.sequel).to be_a(Sequel::SQLite::Database)
       end
+
+      it 'disables preconnect on the initial network connection attempt' do
+        captured_opts = nil
+        allow(Sequel).to receive(:connect).and_wrap_original do |original, *args, **kwargs|
+          options = kwargs.empty? ? args.last : kwargs
+          captured_opts = options if options[:adapter] == :mysql2
+          raise Sequel::DatabaseConnectionError, 'connection refused' if options[:adapter] == :mysql2
+
+          original.call(*args, **kwargs)
+        end
+
+        described_class.setup
+
+        expect(captured_opts[:preconnect]).to be(false)
+      end
     end
 
     context 'when dev_mode is false and network DB unreachable' do

--- a/spec/legion/data/connection_spec.rb
+++ b/spec/legion/data/connection_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe 'Legion::Data::Connection' do
     expect(Legion::Data::Connection.sequel.loggers).to be_a Array
     expect(Legion::Data::Connection.sequel.loggers.count).to be > 0
     expect(Legion::Data::Connection.sequel.loggers.first).to be_a Legion::Data::Connection::SlowQueryLogger
+    expect(Legion::Data::Connection.sequel.loggers.first.tagged.segments).to eq(%w[data connection])
   end
 
   it 'uses other things' do

--- a/spec/legion/data/encryption/sequel_plugin_spec.rb
+++ b/spec/legion/data/encryption/sequel_plugin_spec.rb
@@ -19,4 +19,111 @@ RSpec.describe Legion::Data::Encryption::SequelPlugin do
       expect(klass.encryption_key_provider).to be_a(Legion::Data::Encryption::KeyProvider)
     end
   end
+
+  describe 'integration' do
+    let(:db) do
+      Sequel.sqlite.tap do |database|
+        database.create_table(:encrypted_records) do
+          primary_key :id
+          String :tenant_id
+          column :secret, 'BLOB'
+          column :tenant_secret, 'BLOB'
+        end
+      end
+    end
+
+    let(:model_class) do
+      Class.new(Sequel::Model(db[:encrypted_records])) do
+        plugin Legion::Data::Encryption::SequelPlugin
+        encrypted_column :secret
+        encrypted_column :tenant_secret, key_scope: :tenant
+      end
+    end
+
+    after do
+      db.disconnect
+    end
+
+    it 'decrypts a newly-created persisted row' do
+      record = model_class.create(secret: 'hello')
+
+      expect(model_class[record.id].secret).to eq('hello')
+    end
+
+    it 're-encrypts newly-created rows with their persisted primary key' do
+      record = model_class.create(secret: 'hello')
+      blob = db[:encrypted_records].where(id: record.id).get(:secret)
+      key = model_class.encryption_key_provider.key_for
+
+      expect(
+        Legion::Data::Encryption::Cipher.decrypt(
+          blob,
+          key: key,
+          aad: Legion::Data::Encryption::SequelPlugin.aad_for(
+            table_name:  :encrypted_records,
+            primary_key: record.id,
+            column:      :secret
+          )
+        )
+      ).to eq('hello')
+
+      expect do
+        Legion::Data::Encryption::Cipher.decrypt(
+          blob,
+          key: key,
+          aad: Legion::Data::Encryption::SequelPlugin.aad_for(
+            table_name:  :encrypted_records,
+            primary_key: 0,
+            column:      :secret
+          )
+        )
+      end.to raise_error(OpenSSL::Cipher::CipherError)
+    end
+
+    it 'still reads rows encrypted with the legacy pre-persist AAD' do
+      key = model_class.encryption_key_provider.key_for
+      blob = Legion::Data::Encryption::Cipher.encrypt(
+        'hello',
+        key: key,
+        aad: Legion::Data::Encryption::SequelPlugin.aad_for(
+          table_name:  :encrypted_records,
+          primary_key: 0,
+          column:      :secret
+        )
+      )
+      id = db[:encrypted_records].insert(secret: Sequel.blob(blob))
+
+      expect(model_class[id].secret).to eq('hello')
+    end
+
+    it 'decrypts updates on already-persisted rows' do
+      record = model_class.create(secret: 'hello')
+
+      record.update(secret: 'world')
+
+      expect(model_class[record.id].secret).to eq('world')
+    end
+
+    it 'preserves nil encrypted columns' do
+      record = model_class.create(secret: nil, tenant_secret: nil)
+      reloaded = model_class[record.id]
+
+      expect(reloaded.secret).to be_nil
+      expect(reloaded.tenant_secret).to be_nil
+    end
+
+    it 'decrypts tenant-scoped columns after persistence' do
+      provider = instance_double(Legion::Data::Encryption::KeyProvider)
+      allow(provider).to receive(:key_for) do |tenant_id: nil|
+        OpenSSL::Digest.digest('SHA256', "tenant:#{tenant_id}")
+      end
+      model_class.instance_variable_set(:@encryption_key_provider, provider)
+
+      record = model_class.create(tenant_id: 'tenant-a', tenant_secret: 'hello')
+      reloaded = model_class[record.id]
+
+      expect(reloaded.tenant_secret).to eq('hello')
+      expect(provider).to have_received(:key_for).with(tenant_id: 'tenant-a').at_least(:once)
+    end
+  end
 end

--- a/spec/legion/data/event_store_spec.rb
+++ b/spec/legion/data/event_store_spec.rb
@@ -4,6 +4,26 @@ require 'spec_helper'
 require 'legion/data/event_store'
 
 RSpec.describe Legion::Data::EventStore do
+  let(:db) do
+    Sequel.sqlite.tap do |database|
+      database.create_table(:governance_events) do
+        primary_key :id
+        String :stream_id, null: false
+        String :event_type, null: false
+        Integer :sequence_number, null: false
+        column :data_json, :text
+        column :metadata_json, :text
+        String :event_hash, size: 64
+        String :previous_hash, size: 64
+        DateTime :created_at, null: false, default: Sequel::CURRENT_TIMESTAMP
+      end
+    end
+  end
+
+  after do
+    db.disconnect if defined?(db) && db
+  end
+
   describe 'GOVERNANCE_EVENT_TYPES' do
     it 'includes consent and extinction events' do
       expect(described_class::GOVERNANCE_EVENT_TYPES).to include('consent.granted', 'extinction.triggered')
@@ -30,6 +50,87 @@ RSpec.describe Legion::Data::EventStore do
       allow(described_class).to receive(:db_ready?).and_return(false)
       result = described_class.verify_chain('test')
       expect(result[:valid]).to be false
+    end
+  end
+
+  context 'with a live database' do
+    before do
+      allow(Legion::Data).to receive(:connection).and_return(db)
+      allow(described_class).to receive(:db_ready?).and_return(true)
+    end
+
+    it 'round-trips data and metadata through append and read_stream' do
+      described_class.append(
+        stream: 'stream-1',
+        type: 'consent.granted',
+        data: { granted: true },
+        metadata: { request_id: 'req-1', actor: 'worker-1' }
+      )
+
+      events = described_class.read_stream('stream-1')
+
+      expect(events.size).to eq(1)
+      expect(events.first[:data]).to eq({ granted: true })
+      expect(events.first[:metadata]).to eq({ request_id: 'req-1', actor: 'worker-1' })
+    end
+
+    it 'verifies a multi-event chain when metadata is unchanged' do
+      described_class.append(
+        stream: 'stream-2',
+        type: 'consent.granted',
+        data: { step: 1 },
+        metadata: { request_id: 'req-1' }
+      )
+      described_class.append(
+        stream: 'stream-2',
+        type: 'consent.modified',
+        data: { step: 2 },
+        metadata: { request_id: 'req-2' }
+      )
+
+      result = described_class.verify_chain('stream-2')
+
+      expect(result).to eq(valid: true, length: 2)
+    end
+
+    it 'detects metadata tampering for newly-written rows' do
+      described_class.append(
+        stream: 'stream-3',
+        type: 'consent.granted',
+        data: { granted: true },
+        metadata: { request_id: 'req-1' }
+      )
+
+      db[:governance_events].where(stream_id: 'stream-3', sequence_number: 1)
+        .update(metadata_json: Legion::JSON.dump(request_id: 'tampered'))
+
+      result = described_class.verify_chain('stream-3')
+
+      expect(result).to eq(valid: false, broken_at: 1)
+    end
+
+    it 'continues to verify legacy rows hashed without metadata_json' do
+      stream = 'legacy-stream'
+      type = 'consent.granted'
+      data_json = Legion::JSON.dump(granted: true)
+      metadata_json = Legion::JSON.dump(request_id: 'req-1')
+      previous_hash = '0' * 64
+      legacy_hash = Digest::SHA256.hexdigest("#{stream}:1:#{type}:#{data_json}:#{previous_hash}")
+
+      db[:governance_events].insert(
+        stream_id: stream,
+        event_type: type,
+        sequence_number: 1,
+        data_json: data_json,
+        metadata_json: metadata_json,
+        event_hash: legacy_hash,
+        previous_hash: previous_hash,
+        created_at: Time.now
+      )
+
+      result = described_class.verify_chain(stream)
+
+      expect(result).to eq(valid: true, length: 1, legacy_hashes: 1)
     end
   end
 end

--- a/spec/legion/data/event_store_spec.rb
+++ b/spec/legion/data/event_store_spec.rb
@@ -61,9 +61,9 @@ RSpec.describe Legion::Data::EventStore do
 
     it 'round-trips data and metadata through append and read_stream' do
       described_class.append(
-        stream: 'stream-1',
-        type: 'consent.granted',
-        data: { granted: true },
+        stream:   'stream-1',
+        type:     'consent.granted',
+        data:     { granted: true },
         metadata: { request_id: 'req-1', actor: 'worker-1' }
       )
 
@@ -76,15 +76,15 @@ RSpec.describe Legion::Data::EventStore do
 
     it 'verifies a multi-event chain when metadata is unchanged' do
       described_class.append(
-        stream: 'stream-2',
-        type: 'consent.granted',
-        data: { step: 1 },
+        stream:   'stream-2',
+        type:     'consent.granted',
+        data:     { step: 1 },
         metadata: { request_id: 'req-1' }
       )
       described_class.append(
-        stream: 'stream-2',
-        type: 'consent.modified',
-        data: { step: 2 },
+        stream:   'stream-2',
+        type:     'consent.modified',
+        data:     { step: 2 },
         metadata: { request_id: 'req-2' }
       )
 
@@ -95,13 +95,14 @@ RSpec.describe Legion::Data::EventStore do
 
     it 'detects metadata tampering for newly-written rows' do
       described_class.append(
-        stream: 'stream-3',
-        type: 'consent.granted',
-        data: { granted: true },
+        stream:   'stream-3',
+        type:     'consent.granted',
+        data:     { granted: true },
         metadata: { request_id: 'req-1' }
       )
 
-      db[:governance_events].where(stream_id: 'stream-3', sequence_number: 1)
+      db[:governance_events]
+        .where(stream_id: 'stream-3', sequence_number: 1)
         .update(metadata_json: Legion::JSON.dump(request_id: 'tampered'))
 
       result = described_class.verify_chain('stream-3')
@@ -118,14 +119,14 @@ RSpec.describe Legion::Data::EventStore do
       legacy_hash = Digest::SHA256.hexdigest("#{stream}:1:#{type}:#{data_json}:#{previous_hash}")
 
       db[:governance_events].insert(
-        stream_id: stream,
-        event_type: type,
+        stream_id:       stream,
+        event_type:      type,
         sequence_number: 1,
-        data_json: data_json,
-        metadata_json: metadata_json,
-        event_hash: legacy_hash,
-        previous_hash: previous_hash,
-        created_at: Time.now
+        data_json:       data_json,
+        metadata_json:   metadata_json,
+        event_hash:      legacy_hash,
+        previous_hash:   previous_hash,
+        created_at:      Time.now
       )
 
       result = described_class.verify_chain(stream)

--- a/spec/legion/data/helper_spec.rb
+++ b/spec/legion/data/helper_spec.rb
@@ -141,6 +141,7 @@ RSpec.describe Legion::Data::Helper do
     end
 
     it 'returns {} when an error is raised' do
+      allow(Legion::Settings).to receive(:[]).and_return({})
       allow(Legion::Settings).to receive(:[]).with(:data).and_return({ connected: true })
       allow(Legion::Data::Connection).to receive(:pool_stats).and_raise(StandardError)
       expect(instance.data_pool_stats).to eq({})
@@ -168,6 +169,7 @@ RSpec.describe Legion::Data::Helper do
     end
 
     it 'returns {} when an error is raised' do
+      allow(Legion::Settings).to receive(:[]).and_return({})
       allow(Legion::Settings).to receive(:[]).with(:data).and_return({ connected: true })
       allow(Legion::Data).to receive(:stats).and_raise(StandardError)
       expect(instance.data_stats).to eq({})

--- a/spec/legion/data/local_spec.rb
+++ b/spec/legion/data/local_spec.rb
@@ -25,6 +25,13 @@ RSpec.describe Legion::Data::Local do
       expect(described_class.connection).to be_a(Sequel::SQLite::Database)
     end
 
+    it 'uses a local tagged Sequel logger' do
+      described_class.setup(database: test_db)
+      logger = described_class.connection.loggers.first
+      expect(logger).to be_a(Legion::Data::Connection::SlowQueryLogger)
+      expect(logger.tagged.segments).to eq(%w[data local])
+    end
+
     it 'sets connected to true' do
       described_class.setup(database: test_db)
       expect(described_class.connected?).to be true

--- a/spec/legion/data/partition_manager_spec.rb
+++ b/spec/legion/data/partition_manager_spec.rb
@@ -283,9 +283,8 @@ RSpec.describe Legion::Data::PartitionManager do
       allow(mock_db).to receive(:fetch).and_return([])
     end
 
-    it 'does not raise when Legion::Logging is not defined' do
-      # Hide Legion::Logging from the constant lookup without actually removing it
-      allow(described_class).to receive(:logging?).and_return(false)
+    it 'does not raise when log helper is available' do
+      allow(described_class).to receive(:log).and_return(instance_double('Legion::Logging::TaggedLogger', info: nil))
 
       expect { described_class.ensure_partitions(table: :events, months_ahead: 1) }.not_to raise_error
       expect { described_class.drop_old_partitions(table: :events, retention_months: 24) }.not_to raise_error

--- a/spec/legion/data/partition_manager_spec.rb
+++ b/spec/legion/data/partition_manager_spec.rb
@@ -263,13 +263,12 @@ RSpec.describe Legion::Data::PartitionManager do
         fetch_calls == 1 ? [] : [{ name: 'events_y2025m01' }]
       end
 
-      logging_double = double('Legion::Logging')
-      allow(logging_double).to receive(:info)
-      stub_const('Legion::Logging', logging_double)
+      logger = instance_double('Legion::Logging::TaggedLogger', info: nil)
+      allow(described_class).to receive(:log).and_return(logger)
 
       described_class.ensure_partitions(table: :events, months_ahead: 1)
 
-      expect(logging_double).to have_received(:info).at_least(:once)
+      expect(logger).to have_received(:info).at_least(:once)
     end
   end
 

--- a/spec/legion/data/privilege_spec.rb
+++ b/spec/legion/data/privilege_spec.rb
@@ -75,6 +75,7 @@ RSpec.describe 'Legion::Data privilege checks' do
     end
 
     it 'returns false on error' do
+      allow(Legion::Settings).to receive(:[]).and_return({})
       allow(Legion::Settings).to receive(:[]).with(:data).and_raise(StandardError)
       expect(Legion::Data.connected?).to be false
     end

--- a/spec/legion/data/spool_spec.rb
+++ b/spec/legion/data/spool_spec.rb
@@ -67,6 +67,8 @@ RSpec.describe Legion::Data::Spool::ScopedSpool do
   let(:tmpdir) { Dir.mktmpdir('legion_spool_spec') }
   let(:spool) { Legion::Data::Spool::ScopedSpool.new(Legion::Extensions::LLM::Gateway, tmpdir) }
   let(:sub_ns) { :metering }
+  let(:subdir) { File.join(tmpdir, 'llm/gateway/metering') }
+  let(:quarantine_dir) { File.join(subdir, 'quarantine') }
 
   after do
     FileUtils.rm_rf(tmpdir)
@@ -94,6 +96,12 @@ RSpec.describe Legion::Data::Spool::ScopedSpool do
       files = Dir[File.join(tmpdir, 'llm/gateway/metering', '*.json')]
       content = JSON.parse(File.read(files.first), symbolize_names: true)
       expect(content).to eq({ key: 'value' })
+    end
+
+    it 'does not leave temporary files behind' do
+      spool.write(sub_ns, key: 'value')
+
+      expect(Dir[File.join(subdir, '.*.tmp-*')]).to be_empty
     end
 
     it 'names files with timestamp-uuid pattern' do
@@ -130,6 +138,30 @@ RSpec.describe Legion::Data::Spool::ScopedSpool do
       spool.write(sub_ns, order: 3)
       events = spool.read(sub_ns)
       expect(events.map { |e| e[:order] }).to eq([1, 2, 3])
+    end
+
+    it 'sorts files by filename before reading' do
+      FileUtils.mkdir_p(subdir)
+      File.binwrite(File.join(subdir, '200.json'), JSON.generate(order: 2))
+      File.binwrite(File.join(subdir, '100.json'), JSON.generate(order: 1))
+      File.binwrite(File.join(subdir, '300.json'), JSON.generate(order: 3))
+
+      events = spool.read(sub_ns)
+
+      expect(events.map { |e| e[:order] }).to eq([1, 2, 3])
+    end
+
+    it 'quarantines corrupt files and continues reading valid ones' do
+      FileUtils.mkdir_p(subdir)
+      File.binwrite(File.join(subdir, '100.json'), JSON.generate(order: 1))
+      File.binwrite(File.join(subdir, '200.json'), '{"order":')
+      File.binwrite(File.join(subdir, '300.json'), JSON.generate(order: 2))
+
+      events = spool.read(sub_ns)
+
+      expect(events.map { |e| e[:order] }).to eq([1, 2])
+      expect(Dir[File.join(quarantine_dir, '*.corrupt')].size).to eq(1)
+      expect(spool.count(sub_ns)).to eq(2)
     end
 
     it 'does not delete files' do
@@ -178,6 +210,21 @@ RSpec.describe Legion::Data::Spool::ScopedSpool do
       seen = []
       spool.flush(sub_ns) { |e| seen << e[:order] }
       expect(seen).to eq([1, 2])
+    end
+
+    it 'quarantines corrupt files and continues draining valid ones' do
+      FileUtils.mkdir_p(subdir)
+      File.binwrite(File.join(subdir, '100.json'), JSON.generate(order: 1))
+      File.binwrite(File.join(subdir, '200.json'), '{"order":')
+      File.binwrite(File.join(subdir, '300.json'), JSON.generate(order: 2))
+
+      seen = []
+      result = spool.flush(sub_ns) { |e| seen << e[:order] }
+
+      expect(seen).to eq([1, 2])
+      expect(result).to eq(2)
+      expect(spool.count(sub_ns)).to eq(0)
+      expect(Dir[File.join(quarantine_dir, '*.corrupt')].size).to eq(1)
     end
   end
 


### PR DESCRIPTION
## What

Uplift logging across non-API `lib/` modules to use `Legion::Logging::Helper`, add helper-backed tagged loggers, and harden a couple of lower-level correctness issues uncovered during review.

Closes #18
Closes #19
Closes #20
Closes #21

## Why

This aligns `legion-data` with newer `legion-logging` helper behavior, improves structured exception logging and tagging, fixes EventStore metadata integrity coverage, fixes encrypted column persistence for newly-created rows, and makes spool replay deterministic and resilient to partial or corrupt files.

## Checklist

- [x] Tests pass (`bundle exec rspec`)
- [ ] RuboCop passes (`bundle exec rubocop`)
- [x] CHANGELOG.md updated (if user-facing change)
- [x] No new security concerns introduced
