### PR TITLE
add migration 062: tool_embedding_cache table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ legion.log
 .DS_Store
 # SQLite database files
 *.db
+.worktrees

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- Migration 062: `tool_embedding_cache` table for global embedding persistence
+
 ## [1.6.20] - 2026-04-03
 
 ### Fixed

--- a/lib/legion/data/migrations/062_create_tool_embedding_cache.rb
+++ b/lib/legion/data/migrations/062_create_tool_embedding_cache.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Sequel.migration do
   change do
     create_table(:tool_embedding_cache) do

--- a/lib/legion/data/migrations/062_create_tool_embedding_cache.rb
+++ b/lib/legion/data/migrations/062_create_tool_embedding_cache.rb
@@ -1,0 +1,15 @@
+Sequel.migration do
+  change do
+    create_table(:tool_embedding_cache) do
+      primary_key :id
+      String :content_hash, size: 32, null: false
+      String :model, size: 100, null: false
+      String :tool_name, size: 200, null: false
+      column :vector, :text, null: false
+      DateTime :embedded_at, null: false
+      DateTime :created_at, null: false, default: Sequel::CURRENT_TIMESTAMP
+      unique %i[content_hash model]
+      index :tool_name
+    end
+  end
+end

--- a/lib/legion/data/version.rb
+++ b/lib/legion/data/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Data
-    VERSION = '1.6.20'
+    VERSION = '1.6.21'
   end
 end


### PR DESCRIPTION
## Summary
- Migration 062: `tool_embedding_cache` table for global embedding persistence
- Supports the 5-tier EmbeddingCache in LegionIO (Tier 4: global PostgreSQL)

## Coordinated PRs
- LegionIO/LegionIO — Tool Registry foundation + EmbeddingCache
- LegionIO/legion-llm — ToolAdapter/ToolDiscovery
- LegionIO/legion-mcp — MCP reads from Registry

## Test plan
- [x] 530 examples, 0 failures (19 pending — no DB connection expected)
- [x] rubocop 0 offenses