### PR TITLE
add identity schema and migration mode gate (phase 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ## [Unreleased]
 
+## [1.6.22] - 2026-04-06
+
+### Added
+- Migration 063: `identity_providers` table (provider_type, facing, priority, trust_weight, capabilities)
+- Migration 064: `principals` table (canonical_name regex constraint, kind, unique composite)
+- Migration 065: `identities` table (principal/provider FKs, partial unique index on active)
+- Migration 066: `identity_groups` table (source: ldap/entra/manual)
+- Migration 067: `identity_group_memberships` table (status, trust_weight, discovered_by, tie-break index)
+- Migration 068: `entity_type` column on `audit_records` with index
+- Migration 069: `principal_id` FK on `nodes` table
+- 5 Sequel models: `IdentityProvider`, `Principal`, `Identity`, `IdentityGroup`, `IdentityGroupMembership`
+- `Identity` model wired through `SequelPlugin` `encrypted_column :profile` for at-rest encryption
+- `Node` model gains `many_to_one :principal` association
+
+### Changed
+- Migration mode gate: only `:infra` mode runs migrations when `Legion::Mode` is available
+- `auto_migrate` settings check wired into `Data.setup` (skips migrations when `auto_migrate: false`)
+- Mode guard added to both `Data.migrate` and `Migration.migrate` for defense-in-depth
+
+## [1.6.21] - 2026-04-05
+
 ### Added
 - Migration 062: `tool_embedding_cache` table for global embedding persistence
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 Manages persistent database storage for the LegionIO framework. Supports SQLite (default), MySQL, and PostgreSQL via Sequel ORM. Provides automatic schema migrations and data models for extensions, functions, runners, nodes, tasks, settings, digital workers, task relationships, Apollo shared knowledge tables (PostgreSQL only), tenants, webhooks, audit log, and archive tables. Also provides a parallel local SQLite database (`Legion::Data::Local`) for agentic cognitive state persistence.
 
 **GitHub**: https://github.com/LegionIO/legion-data
-**Version**: 1.6.11
+**Version**: 1.6.21
 **License**: Apache-2.0
 
 ## Supported Databases
@@ -56,7 +56,7 @@ Legion::Data (singleton module)
 │   ├── .shutdown      # Close local connection
 │   └── .reset!        # Clear all state (testing)
 │
-├── Migration          # Auto-migration system (57 migrations, Sequel DSL)
+├── Migration          # Auto-migration system (58 migrations, Sequel DSL)
 │   └── migrations/
 │       ├── 001_add_schema_columns
 │       ├── 002_add_nodes
@@ -114,7 +114,8 @@ Legion::Data (singleton module)
 │       ├── 054_add_component_type_to_functions  # component_type on functions (runner/hook/absorber, v3.0)
 │       ├── 055_add_definition_to_functions      # definition text column on functions (v3.0)
 │       ├── 056_add_absorber_patterns       # absorber_patterns table for pattern-matched acquisition
-│       └── 057_add_routing_key_to_runners  # routing_key on runners (v3.0 AMQP)
+│       ├── 057_add_routing_key_to_runners  # routing_key on runners (v3.0 AMQP)
+│       └── 058_add_tool_embedding_cache    # tool_embedding_cache table for global embedding cache tier (Tools::EmbeddingCache L4)
 │
 ├── Model              # Sequel model loader
 │   └── Models/
@@ -279,7 +280,7 @@ Per-adapter credential defaults are defined in `Settings::CREDS`:
 | `lib/legion/data.rb` | Module entry, setup/shutdown lifecycle |
 | `lib/legion/data/connection.rb` | Sequel database connection (adapter selection) |
 | `lib/legion/data/migration.rb` | Migration runner |
-| `lib/legion/data/migrations/` | 48 numbered migration files (Sequel DSL) |
+| `lib/legion/data/migrations/` | 58 numbered migration files (Sequel DSL) |
 | `lib/legion/data/model.rb` | Model autoloader |
 | `lib/legion/data/local.rb` | Local SQLite module for agentic cognitive state |
 | `lib/legion/data/models/` | Sequel models (Extension, Function, Runner, Node, Task, TaskLog, Setting, DigitalWorker, Relationship, ApolloEntry, ApolloRelation, ApolloExpertise, ApolloAccessLog, AuditLog, RbacRoleAssignment, RbacRunnerGrant, RbacCrossTeamGrant) |
@@ -320,6 +321,7 @@ Optional persistent storage initialized during `Legion::Service` startup (after 
 13. Archive, memory traces, and tenant partition tables (migrations 021–025)
 14. Function embeddings for semantic runner discovery (migration 026 — description + vector columns on functions table)
 15. Financial logging for UAIS cost recovery (migration 048 — 7 tables: identity, asset, environment, accounting, execution, tags, usage rollup)
+16. Global tool embedding cache (migration 058 — `tool_embedding_cache` table, L4 tier for `Legion::Tools::EmbeddingCache`)
 
 ---
 

--- a/lib/legion/data.rb
+++ b/lib/legion/data.rb
@@ -185,11 +185,9 @@ module Legion
         end
 
         # Check mode gate: only infra mode runs migrations (when Mode is available)
-        if defined?(Legion::Mode) && Legion::Mode.respond_to?(:current)
-          unless Legion::Mode.infra?
-            log.info "Legion::Data migrations skipped (mode: #{Legion::Mode.current}, requires: infra)"
-            return true
-          end
+        if defined?(Legion::Mode) && Legion::Mode.respond_to?(:current) && !Legion::Mode.infra?
+          log.info "Legion::Data migrations skipped (mode: #{Legion::Mode.current}, requires: infra)"
+          return true
         end
 
         false

--- a/lib/legion/data.rb
+++ b/lib/legion/data.rb
@@ -58,6 +58,8 @@ module Legion
       end
 
       def migrate
+        return if skip_migrations?
+
         Legion::Data::Migration.migrate
       end
 
@@ -173,6 +175,25 @@ module Legion
       end
 
       private
+
+      def skip_migrations?
+        # Check auto_migrate setting
+        auto_migrate = Legion::Settings[:data][:migrations][:auto_migrate]
+        unless auto_migrate
+          log.info 'Legion::Data migrations skipped (auto_migrate: false)'
+          return true
+        end
+
+        # Check mode gate: only infra mode runs migrations (when Mode is available)
+        if defined?(Legion::Mode) && Legion::Mode.respond_to?(:current)
+          unless Legion::Mode.infra?
+            log.info "Legion::Data migrations skipped (mode: #{Legion::Mode.current}, requires: infra)"
+            return true
+          end
+        end
+
+        false
+      end
 
       def setup_local
         return if Legion::Settings[:data].dig(:local, :enabled) == false

--- a/lib/legion/data/migration.rb
+++ b/lib/legion/data/migration.rb
@@ -11,6 +11,11 @@ module Legion
         include Legion::Logging::Helper
 
         def migrate(connection = Legion::Data.connection, path = "#{__dir__}/migrations", **)
+          if defined?(Legion::Mode) && Legion::Mode.respond_to?(:current) && !Legion::Mode.infra?
+            log.info "Legion::Data::Migration skipped (mode: #{Legion::Mode.current}, requires: infra)"
+            return
+          end
+
           Legion::Settings[:data][:migrations][:version] = Sequel::Migrator.run(connection, path, **)
           log.info("Legion::Data::Migration ran successfully to version #{Legion::Settings[:data][:migrations][:version]}")
           Legion::Settings[:data][:migrations][:ran] = true

--- a/lib/legion/data/migrations/063_create_identity_providers.rb
+++ b/lib/legion/data/migrations/063_create_identity_providers.rb
@@ -2,17 +2,17 @@
 
 Sequel.migration do
   up do
-    return unless adapter_scheme == :postgres
+    next unless adapter_scheme == :postgres
 
     create_table(:identity_providers) do
-      column :id, :uuid, default: Sequel.lit("gen_random_uuid()"), primary_key: true
+      column :id, :uuid, default: Sequel.lit('gen_random_uuid()'), primary_key: true
       String :name, null: false, unique: true
       String :provider_type, null: false  # authenticate, profile, fallback
       String :facing, null: false         # human, machine, both
       Integer :priority, null: false, default: 100
       Integer :trust_weight, null: false, default: 50
-      column :capabilities, :"text[]", default: Sequel.lit("'{}'")
-      String :source, null: false, default: 'gem'  # gem, db
+      column :capabilities, :'text[]', default: Sequel.lit("'{}'")
+      String :source, null: false, default: 'gem' # gem, db
       TrueClass :enabled, null: false, default: true
       DateTime :created_at, null: false, default: Sequel::CURRENT_TIMESTAMP
       DateTime :updated_at, null: false, default: Sequel::CURRENT_TIMESTAMP
@@ -20,7 +20,7 @@ Sequel.migration do
   end
 
   down do
-    return unless adapter_scheme == :postgres
+    next unless adapter_scheme == :postgres
 
     drop_table?(:identity_providers)
   end

--- a/lib/legion/data/migrations/063_create_identity_providers.rb
+++ b/lib/legion/data/migrations/063_create_identity_providers.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    return unless adapter_scheme == :postgres
+
+    create_table(:identity_providers) do
+      column :id, :uuid, default: Sequel.lit("gen_random_uuid()"), primary_key: true
+      String :name, null: false, unique: true
+      String :provider_type, null: false  # authenticate, profile, fallback
+      String :facing, null: false         # human, machine, both
+      Integer :priority, null: false, default: 100
+      Integer :trust_weight, null: false, default: 50
+      column :capabilities, :"text[]", default: Sequel.lit("'{}'")
+      String :source, null: false, default: 'gem'  # gem, db
+      TrueClass :enabled, null: false, default: true
+      DateTime :created_at, null: false, default: Sequel::CURRENT_TIMESTAMP
+      DateTime :updated_at, null: false, default: Sequel::CURRENT_TIMESTAMP
+    end
+  end
+
+  down do
+    return unless adapter_scheme == :postgres
+
+    drop_table?(:identity_providers)
+  end
+end

--- a/lib/legion/data/migrations/064_create_principals.rb
+++ b/lib/legion/data/migrations/064_create_principals.rb
@@ -2,12 +2,12 @@
 
 Sequel.migration do
   up do
-    return unless adapter_scheme == :postgres
+    next unless adapter_scheme == :postgres
 
     create_table(:principals) do
-      column :id, :uuid, default: Sequel.lit("gen_random_uuid()"), primary_key: true
+      column :id, :uuid, default: Sequel.lit('gen_random_uuid()'), primary_key: true
       String :canonical_name, null: false
-      String :kind, null: false  # human, service, machine
+      String :kind, null: false # human, service, machine
       String :display_name
       TrueClass :active, null: false, default: true
       DateTime :last_seen_at
@@ -15,7 +15,7 @@ Sequel.migration do
       DateTime :updated_at, null: false, default: Sequel::CURRENT_TIMESTAMP
 
       constraint(:canonical_name_format, Sequel.lit("canonical_name ~ '^[a-z0-9][a-z0-9_-]*$'"))
-      unique [:canonical_name, :kind]
+      unique %i[canonical_name kind]
     end
 
     add_index :principals, :canonical_name
@@ -23,7 +23,7 @@ Sequel.migration do
   end
 
   down do
-    return unless adapter_scheme == :postgres
+    next unless adapter_scheme == :postgres
 
     drop_table?(:principals)
   end

--- a/lib/legion/data/migrations/064_create_principals.rb
+++ b/lib/legion/data/migrations/064_create_principals.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    return unless adapter_scheme == :postgres
+
+    create_table(:principals) do
+      column :id, :uuid, default: Sequel.lit("gen_random_uuid()"), primary_key: true
+      String :canonical_name, null: false
+      String :kind, null: false  # human, service, machine
+      String :display_name
+      TrueClass :active, null: false, default: true
+      DateTime :last_seen_at
+      DateTime :created_at, null: false, default: Sequel::CURRENT_TIMESTAMP
+      DateTime :updated_at, null: false, default: Sequel::CURRENT_TIMESTAMP
+
+      constraint(:canonical_name_format, Sequel.lit("canonical_name ~ '^[a-z0-9][a-z0-9_-]*$'"))
+      unique [:canonical_name, :kind]
+    end
+
+    add_index :principals, :canonical_name
+    add_index :principals, :kind
+  end
+
+  down do
+    return unless adapter_scheme == :postgres
+
+    drop_table?(:principals)
+  end
+end

--- a/lib/legion/data/migrations/065_create_identities.rb
+++ b/lib/legion/data/migrations/065_create_identities.rb
@@ -2,31 +2,31 @@
 
 Sequel.migration do
   up do
-    return unless adapter_scheme == :postgres
+    next unless adapter_scheme == :postgres
 
     create_table(:identities) do
-      column :id, :uuid, default: Sequel.lit("gen_random_uuid()"), primary_key: true
+      column :id, :uuid, default: Sequel.lit('gen_random_uuid()'), primary_key: true
       foreign_key :principal_id, :principals, type: :uuid, null: false, on_delete: :cascade
       foreign_key :provider_id, :identity_providers, type: :uuid, null: false, on_delete: :cascade
-      String :provider_identity, null: false  # external ID from provider
-      column :profile, :jsonb, default: Sequel.lit("'{}'::jsonb")
+      String :provider_identity, null: false # external ID from provider
+      column :profile, :bytea
       TrueClass :active, null: false, default: true
       DateTime :last_authenticated_at
       DateTime :created_at, null: false, default: Sequel::CURRENT_TIMESTAMP
       DateTime :updated_at, null: false, default: Sequel::CURRENT_TIMESTAMP
 
-      unique [:principal_id, :provider_id, :provider_identity]
+      unique %i[principal_id provider_id provider_identity]
     end
 
     # Partial unique index: only one active identity per provider+provider_identity
-    run "CREATE UNIQUE INDEX identities_active_provider_uniq ON identities (provider_id, provider_identity) WHERE active = true"
+    run 'CREATE UNIQUE INDEX identities_active_provider_uniq ON identities (provider_id, provider_identity) WHERE active = true'
 
     add_index :identities, :principal_id
     add_index :identities, :provider_id
   end
 
   down do
-    return unless adapter_scheme == :postgres
+    next unless adapter_scheme == :postgres
 
     drop_table?(:identities)
   end

--- a/lib/legion/data/migrations/065_create_identities.rb
+++ b/lib/legion/data/migrations/065_create_identities.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    return unless adapter_scheme == :postgres
+
+    create_table(:identities) do
+      column :id, :uuid, default: Sequel.lit("gen_random_uuid()"), primary_key: true
+      foreign_key :principal_id, :principals, type: :uuid, null: false, on_delete: :cascade
+      foreign_key :provider_id, :identity_providers, type: :uuid, null: false, on_delete: :cascade
+      String :provider_identity, null: false  # external ID from provider
+      column :profile, :jsonb, default: Sequel.lit("'{}'::jsonb")
+      TrueClass :active, null: false, default: true
+      DateTime :last_authenticated_at
+      DateTime :created_at, null: false, default: Sequel::CURRENT_TIMESTAMP
+      DateTime :updated_at, null: false, default: Sequel::CURRENT_TIMESTAMP
+
+      unique [:principal_id, :provider_id, :provider_identity]
+    end
+
+    # Partial unique index: only one active identity per provider+provider_identity
+    run "CREATE UNIQUE INDEX identities_active_provider_uniq ON identities (provider_id, provider_identity) WHERE active = true"
+
+    add_index :identities, :principal_id
+    add_index :identities, :provider_id
+  end
+
+  down do
+    return unless adapter_scheme == :postgres
+
+    drop_table?(:identities)
+  end
+end

--- a/lib/legion/data/migrations/066_create_identity_groups.rb
+++ b/lib/legion/data/migrations/066_create_identity_groups.rb
@@ -2,12 +2,12 @@
 
 Sequel.migration do
   up do
-    return unless adapter_scheme == :postgres
+    next unless adapter_scheme == :postgres
 
     create_table(:identity_groups) do
-      column :id, :uuid, default: Sequel.lit("gen_random_uuid()"), primary_key: true
+      column :id, :uuid, default: Sequel.lit('gen_random_uuid()'), primary_key: true
       String :name, null: false, unique: true
-      String :source, null: false, default: 'ldap'  # ldap, entra, manual
+      String :source, null: false, default: 'ldap' # ldap, entra, manual
       String :description
       TrueClass :active, null: false, default: true
       DateTime :created_at, null: false, default: Sequel::CURRENT_TIMESTAMP
@@ -16,7 +16,7 @@ Sequel.migration do
   end
 
   down do
-    return unless adapter_scheme == :postgres
+    next unless adapter_scheme == :postgres
 
     drop_table?(:identity_groups)
   end

--- a/lib/legion/data/migrations/066_create_identity_groups.rb
+++ b/lib/legion/data/migrations/066_create_identity_groups.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    return unless adapter_scheme == :postgres
+
+    create_table(:identity_groups) do
+      column :id, :uuid, default: Sequel.lit("gen_random_uuid()"), primary_key: true
+      String :name, null: false, unique: true
+      String :source, null: false, default: 'ldap'  # ldap, entra, manual
+      String :description
+      TrueClass :active, null: false, default: true
+      DateTime :created_at, null: false, default: Sequel::CURRENT_TIMESTAMP
+      DateTime :updated_at, null: false, default: Sequel::CURRENT_TIMESTAMP
+    end
+  end
+
+  down do
+    return unless adapter_scheme == :postgres
+
+    drop_table?(:identity_groups)
+  end
+end

--- a/lib/legion/data/migrations/067_create_identity_group_memberships.rb
+++ b/lib/legion/data/migrations/067_create_identity_group_memberships.rb
@@ -2,20 +2,20 @@
 
 Sequel.migration do
   up do
-    return unless adapter_scheme == :postgres
+    next unless adapter_scheme == :postgres
 
     create_table(:identity_group_memberships) do
-      column :id, :uuid, default: Sequel.lit("gen_random_uuid()"), primary_key: true
+      column :id, :uuid, default: Sequel.lit('gen_random_uuid()'), primary_key: true
       foreign_key :principal_id, :principals, type: :uuid, null: false, on_delete: :cascade
       foreign_key :group_id, :identity_groups, type: :uuid, null: false, on_delete: :cascade
-      String :status, null: false, default: 'active'  # active, stale, expired
-      String :discovered_by, null: false  # provider name that discovered this membership
+      String :status, null: false, default: 'active' # active, stale, expired
+      String :discovered_by, null: false # provider name that discovered this membership
       Integer :trust_weight, null: false, default: 50
       DateTime :expires_at
       DateTime :created_at, null: false, default: Sequel::CURRENT_TIMESTAMP
       DateTime :updated_at, null: false, default: Sequel::CURRENT_TIMESTAMP
 
-      unique [:principal_id, :group_id, :discovered_by]
+      unique %i[principal_id group_id discovered_by]
     end
 
     add_index :identity_group_memberships, :principal_id
@@ -29,7 +29,7 @@ Sequel.migration do
   end
 
   down do
-    return unless adapter_scheme == :postgres
+    next unless adapter_scheme == :postgres
 
     drop_table?(:identity_group_memberships)
   end

--- a/lib/legion/data/migrations/067_create_identity_group_memberships.rb
+++ b/lib/legion/data/migrations/067_create_identity_group_memberships.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    return unless adapter_scheme == :postgres
+
+    create_table(:identity_group_memberships) do
+      column :id, :uuid, default: Sequel.lit("gen_random_uuid()"), primary_key: true
+      foreign_key :principal_id, :principals, type: :uuid, null: false, on_delete: :cascade
+      foreign_key :group_id, :identity_groups, type: :uuid, null: false, on_delete: :cascade
+      String :status, null: false, default: 'active'  # active, stale, expired
+      String :discovered_by, null: false  # provider name that discovered this membership
+      Integer :trust_weight, null: false, default: 50
+      DateTime :expires_at
+      DateTime :created_at, null: false, default: Sequel::CURRENT_TIMESTAMP
+      DateTime :updated_at, null: false, default: Sequel::CURRENT_TIMESTAMP
+
+      unique [:principal_id, :group_id, :discovered_by]
+    end
+
+    add_index :identity_group_memberships, :principal_id
+    add_index :identity_group_memberships, :group_id
+    add_index :identity_group_memberships, :status
+    run <<~SQL
+      CREATE INDEX idx_memberships_trust_tiebreak
+        ON identity_group_memberships (principal_id, trust_weight ASC,
+          CASE status WHEN 'expired' THEN 0 WHEN 'stale' THEN 1 WHEN 'active' THEN 2 END ASC)
+    SQL
+  end
+
+  down do
+    return unless adapter_scheme == :postgres
+
+    drop_table?(:identity_group_memberships)
+  end
+end

--- a/lib/legion/data/migrations/068_add_entity_type_to_audit_records.rb
+++ b/lib/legion/data/migrations/068_add_entity_type_to_audit_records.rb
@@ -2,8 +2,8 @@
 
 Sequel.migration do
   up do
-    return unless adapter_scheme == :postgres
-    return unless table_exists?(:audit_records)
+    next unless adapter_scheme == :postgres
+    next unless table_exists?(:audit_records)
 
     alter_table(:audit_records) do
       add_column :entity_type, String, size: 100, null: true
@@ -13,8 +13,8 @@ Sequel.migration do
   end
 
   down do
-    return unless adapter_scheme == :postgres
-    return unless table_exists?(:audit_records)
+    next unless adapter_scheme == :postgres
+    next unless table_exists?(:audit_records)
 
     alter_table(:audit_records) do
       drop_column :entity_type

--- a/lib/legion/data/migrations/068_add_entity_type_to_audit_records.rb
+++ b/lib/legion/data/migrations/068_add_entity_type_to_audit_records.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    return unless adapter_scheme == :postgres
+    return unless table_exists?(:audit_records)
+
+    alter_table(:audit_records) do
+      add_column :entity_type, String, size: 100, null: true
+    end
+
+    add_index :audit_records, :entity_type, name: :idx_audit_records_entity_type
+  end
+
+  down do
+    return unless adapter_scheme == :postgres
+    return unless table_exists?(:audit_records)
+
+    alter_table(:audit_records) do
+      drop_column :entity_type
+    end
+  end
+end

--- a/lib/legion/data/migrations/069_add_principal_id_to_nodes.rb
+++ b/lib/legion/data/migrations/069_add_principal_id_to_nodes.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    return unless adapter_scheme == :postgres
+
+    alter_table(:nodes) do
+      add_column :principal_id, :uuid
+      add_foreign_key [:principal_id], :principals
+    end
+
+    add_index :nodes, :principal_id
+  end
+
+  down do
+    return unless adapter_scheme == :postgres
+
+    alter_table(:nodes) do
+      drop_column :principal_id
+    end
+  end
+end

--- a/lib/legion/data/migrations/069_add_principal_id_to_nodes.rb
+++ b/lib/legion/data/migrations/069_add_principal_id_to_nodes.rb
@@ -2,7 +2,7 @@
 
 Sequel.migration do
   up do
-    return unless adapter_scheme == :postgres
+    next unless adapter_scheme == :postgres
 
     alter_table(:nodes) do
       add_column :principal_id, :uuid
@@ -13,7 +13,7 @@ Sequel.migration do
   end
 
   down do
-    return unless adapter_scheme == :postgres
+    next unless adapter_scheme == :postgres
 
     alter_table(:nodes) do
       drop_column :principal_id

--- a/lib/legion/data/model.rb
+++ b/lib/legion/data/model.rb
@@ -13,7 +13,8 @@ module Legion
         def models
           %w[extension function relationship chain task runner node setting digital_worker
              apollo_entry apollo_relation apollo_expertise apollo_access_log audit_log
-             audit_record]
+             audit_record identity_provider principal identity identity_group
+             identity_group_membership]
         end
 
         def load

--- a/lib/legion/data/models/identity.rb
+++ b/lib/legion/data/models/identity.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+return unless Legion::Data::Connection.adapter == :postgres
+
 module Legion
   module Data
     module Model

--- a/lib/legion/data/models/identity.rb
+++ b/lib/legion/data/models/identity.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Legion
+  module Data
+    module Model
+      class Identity < Sequel::Model(:identities)
+        many_to_one :principal, class: 'Legion::Data::Model::Principal'
+        many_to_one :provider, class: 'Legion::Data::Model::IdentityProvider', key: :provider_id
+
+        if defined?(Legion::Data::Encryption::SequelPlugin)
+          plugin Legion::Data::Encryption::SequelPlugin
+          encrypted_column :profile
+        end
+      end
+    end
+  end
+end

--- a/lib/legion/data/models/identity_group.rb
+++ b/lib/legion/data/models/identity_group.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Legion
+  module Data
+    module Model
+      class IdentityGroup < Sequel::Model(:identity_groups)
+        one_to_many :memberships, class: 'Legion::Data::Model::IdentityGroupMembership', key: :group_id
+      end
+    end
+  end
+end

--- a/lib/legion/data/models/identity_group.rb
+++ b/lib/legion/data/models/identity_group.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+return unless Legion::Data::Connection.adapter == :postgres
+
 module Legion
   module Data
     module Model

--- a/lib/legion/data/models/identity_group_membership.rb
+++ b/lib/legion/data/models/identity_group_membership.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Legion
+  module Data
+    module Model
+      class IdentityGroupMembership < Sequel::Model(:identity_group_memberships)
+        many_to_one :principal, class: 'Legion::Data::Model::Principal'
+        many_to_one :group, class: 'Legion::Data::Model::IdentityGroup', key: :group_id
+
+        def expired?
+          status == 'expired' || (expires_at && Time.now >= expires_at)
+        end
+
+        def stale?
+          status == 'stale'
+        end
+      end
+    end
+  end
+end

--- a/lib/legion/data/models/identity_group_membership.rb
+++ b/lib/legion/data/models/identity_group_membership.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+return unless Legion::Data::Connection.adapter == :postgres
+
 module Legion
   module Data
     module Model

--- a/lib/legion/data/models/identity_provider.rb
+++ b/lib/legion/data/models/identity_provider.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+return unless Legion::Data::Connection.adapter == :postgres
+
 module Legion
   module Data
     module Model

--- a/lib/legion/data/models/identity_provider.rb
+++ b/lib/legion/data/models/identity_provider.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Legion
+  module Data
+    module Model
+      class IdentityProvider < Sequel::Model(:identity_providers)
+        one_to_many :identities, class: 'Legion::Data::Model::Identity'
+
+        def parsed_capabilities
+          Array(capabilities)
+        end
+      end
+    end
+  end
+end

--- a/lib/legion/data/models/node.rb
+++ b/lib/legion/data/models/node.rb
@@ -9,6 +9,7 @@ module Legion
         include Legion::Logging::Helper
 
         # one_to_many :task_log
+        many_to_one :principal, class: 'Legion::Data::Model::Principal'
 
         def parsed_metrics
           return nil unless metrics

--- a/lib/legion/data/models/principal.rb
+++ b/lib/legion/data/models/principal.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Legion
+  module Data
+    module Model
+      class Principal < Sequel::Model(:principals)
+        one_to_many :identities, class: 'Legion::Data::Model::Identity'
+        one_to_many :group_memberships, class: 'Legion::Data::Model::IdentityGroupMembership'
+
+        def active_groups
+          group_memberships_dataset
+            .where(status: 'active')
+            .eager(:group)
+            .all
+            .map(&:group)
+        end
+      end
+    end
+  end
+end

--- a/lib/legion/data/models/principal.rb
+++ b/lib/legion/data/models/principal.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+return unless Legion::Data::Connection.adapter == :postgres
+
 module Legion
   module Data
     module Model

--- a/lib/legion/data/version.rb
+++ b/lib/legion/data/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Data
-    VERSION = '1.6.21'
+    VERSION = '1.6.22'
   end
 end


### PR DESCRIPTION
## Summary

- 7 new postgres-guarded migrations (063-069): identity_providers, principals, identities, identity_groups, identity_group_memberships, entity_type on audit_records, principal_id FK on nodes
- 5 new Sequel models with associations (IdentityProvider, Principal, Identity, IdentityGroup, IdentityGroupMembership)
- Identity model wired through `SequelPlugin` `encrypted_column :profile` for at-rest encryption
- Migration mode gate: only `:infra` mode runs migrations (guarded with `defined?(Legion::Mode)`)
- `auto_migrate` settings check wired into `Data.setup`
- Node model gains `many_to_one :principal` association

## Dependencies

Part of unified identity Phase 2 — companion PRs:
- **LegionIO**: LegionIO/LegionIO#45 (core identity module)
- **legion-crypt**: LegionIO/legion-crypt#14 (JWKS + bootstrap TTL)

## Test plan

- [ ] `bundle exec rspec` passes
- [ ] `bundle exec rubocop -A` passes
- [ ] Verify migrations are postgres-guarded (skip on SQLite)
- [ ] Verify migration mode gate skips when `Mode.current != :infra`
- [ ] Verify `auto_migrate: false` prevents migrations