### PR TITLE
fleet(data): add approval queue resume columns (migration 070)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [1.6.24] - 2026-04-13
+
+### Added
+- Migration 070: `resume_routing_key` and `resume_exchange` columns on `approval_queue` table (nullable String 255) to support fleet pipeline resume on approval
+
 ## [1.6.23] - 2026-04-07
 
 ### Fixed

--- a/lib/legion/data/migrations/070_add_approval_queue_resume.rb
+++ b/lib/legion/data/migrations/070_add_approval_queue_resume.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    alter_table(:approval_queue) do
+      add_column :resume_routing_key, String, size: 255, null: true
+      add_column :resume_exchange, String, size: 255, null: true
+    end
+  end
+
+  down do
+    alter_table(:approval_queue) do
+      drop_column :resume_routing_key
+      drop_column :resume_exchange
+    end
+  end
+end

--- a/lib/legion/data/version.rb
+++ b/lib/legion/data/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Data
-    VERSION = '1.6.23'
+    VERSION = '1.6.24'
   end
 end


### PR DESCRIPTION
## Summary

- Adds `resume_routing_key` (String, 255, nullable) and `resume_exchange` (String, 255, nullable) columns to the `approval_queue` table via Sequel migration 070
- Reversible: `down` block drops both columns

## Motivation

Part of Fleet WS-03. The `lex-audit` ApprovalQueue runner needs to store a routing key and exchange name at submit time so that `approve` can republish the suspended work item back into the fleet pipeline.

## Test plan

- [ ] Migration 070 applies cleanly (`bundle exec sequel -m lib/legion/data/migrations db_url`)
- [ ] Migration 070 rolls back cleanly
- [ ] Full legion-data test suite passes (530 examples, 0 failures)
- [ ] Rubocop: 0 offenses

## Dependencies

Must merge before: `LegionIO/lex-audit` fleet/ws-03-audit-resume PR (which stores and reads these columns)