### PR TITLE
reduce connection_validation_timeout default to -1 for instant stale …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+## [1.6.27] - 2026-04-17
+
+### Fixed
+- `load_sequel_model` now reads `settings[:models][:continue_on_load_fail]` (was erroneously reading `continue_on_fail`, a key that never existed — LoadError was always re-raised regardless of the setting). (Fixes #22)
+- `load_models` now skips model loading when `settings[:models][:autoload]` is `false`, honoring the documented knob. (Fixes #22)
+- Audit record live-path specs (`append`, `verify`, `walk`, `query_by_type`, immutability guards) are now self-sufficient: the `before` block reconnects the DB if a prior spec tore it down, eliminating 19 pending examples when running the full suite. (Fixes #22)
+- Default `preconnect` changed from `'concurrently'` to `false`. The concurrent preconnect mode spawned background threads that emitted noisy connection errors when a network adapter was unreachable before dev-fallback could catch the failure. `false` preserves identical behavior for SQLite (default) and avoids the noise for production deployments where operators can opt-in explicitly. (Fixes #22)
+
 ## [1.6.26] - 2026-04-17
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [1.6.26] - 2026-04-17
+
+### Fixed
+- `connection_validation_timeout` default reduced from 600s to -1 (validate every checkout) for non-SQLite adapters. The previous 10-minute window meant stale PG connections from a VPN drop, sleep/wake, or network interface change were not evicted until the next scheduled validation cycle, causing `Sequel::DatabaseDisconnectError` to repeat on every actor tick. With -1, Sequel pings the connection on every pool checkout and discards dead connections immediately. (Fixes #28)
+
 ## [1.6.24] - 2026-04-13
 
 ### Added

--- a/lib/legion/data.rb
+++ b/lib/legion/data.rb
@@ -64,6 +64,8 @@ module Legion
       end
 
       def load_models
+        return unless Legion::Settings[:data][:models][:autoload] != false
+
         Legion::Data::Models.load
       end
 

--- a/lib/legion/data/archiver.rb
+++ b/lib/legion/data/archiver.rb
@@ -158,11 +158,7 @@ module Legion
         end
 
         def json_dump(obj)
-          if defined?(Legion::JSON)
-            Legion::JSON.dump(obj)
-          else
-            ::JSON.generate(obj)
-          end
+          ::JSON.generate(obj)
         end
 
         def gzip_compress(data)

--- a/lib/legion/data/audit_record.rb
+++ b/lib/legion/data/audit_record.rb
@@ -25,7 +25,7 @@ module Legion
           conn = Legion::Data.connection
           conn.transaction do
             parent_hash = latest_chain_hash(conn, chain_id)
-            ts          = Time.now
+            ts          = truncate_to_us(Time.now)
             ch          = compute_chain_hash(parent_hash, content_hash, ts, content_type)
             sig         = sign ? sign_record(ch) : nil
             meta_json   = metadata.empty? ? nil : Legion::JSON.dump(metadata)
@@ -104,31 +104,35 @@ module Legion
           ds.order(Sequel.desc(:created_at)).limit(limit).all.map { |r| deserialize(r) }
         end
 
-        # SHA-256 of "parent_hash:content_hash:unix_ts_ns:content_type".
+        # SHA-256 of "parent_hash:content_hash:unix_ts_us:content_type".
         #
-        # The timestamp is normalised to nanoseconds-since-epoch so the hash is
-        # independent of time zone, string formatting, and database type.
-        # Exposed as a public method so callers can independently verify a hash
-        # without querying the database.
+        # The timestamp is normalised to microseconds-since-epoch. PostgreSQL
+        # TIMESTAMP columns have microsecond precision, so nanosecond values
+        # written by Ruby would be truncated on read, causing recomputed hashes
+        # to diverge. Microsecond normalisation keeps write-time and read-time
+        # hashes identical across all supported adapters.
         def compute_chain_hash(parent_hash, content_hash, timestamp, content_type)
-          ts_ns = normalise_timestamp_ns(timestamp)
-          Digest::SHA256.hexdigest("#{parent_hash}:#{content_hash}:#{ts_ns}:#{content_type}")
+          ts_us = normalise_timestamp_us(timestamp)
+          Digest::SHA256.hexdigest("#{parent_hash}:#{content_hash}:#{ts_us}:#{content_type}")
         end
 
         private
 
-        # Normalise a timestamp to integer nanoseconds-since-epoch regardless of
-        # whether the database returned a Time, DateTime, or String.
-        def normalise_timestamp_ns(timestamp)
-          case timestamp
-          when ::Time
-            (timestamp.to_r * 1_000_000_000).to_i
-          when ::DateTime
-            (timestamp.to_time.to_r * 1_000_000_000).to_i
-          else
-            ts = ::Time.parse(timestamp.to_s)
-            (ts.to_r * 1_000_000_000).to_i
-          end
+        # Normalise a timestamp to integer microseconds-since-epoch regardless of
+        # whether the database returned a Time, DateTime, or String. Always uses
+        # the absolute epoch value so timezone differences don't affect the hash.
+        def normalise_timestamp_us(timestamp)
+          t = case timestamp
+              when ::Time     then timestamp
+              when ::DateTime then timestamp.to_time
+              else ::Time.parse(timestamp.to_s)
+              end
+          (t.to_r * 1_000_000).to_i
+        end
+
+        def truncate_to_us(t)
+          us = (t.to_r * 1_000_000).to_i
+          ::Time.at(Rational(us, 1_000_000))
         end
 
         def latest_chain_hash(conn, chain_id)

--- a/lib/legion/data/audit_record.rb
+++ b/lib/legion/data/audit_record.rb
@@ -130,8 +130,8 @@ module Legion
           (t.to_r * 1_000_000).to_i
         end
 
-        def truncate_to_us(t)
-          us = (t.to_r * 1_000_000).to_i
+        def truncate_to_us(time)
+          us = (time.to_r * 1_000_000).to_i
           ::Time.at(Rational(us, 1_000_000))
         end
 

--- a/lib/legion/data/model.rb
+++ b/lib/legion/data/model.rb
@@ -37,7 +37,7 @@ module Legion
           model
         rescue LoadError => e
           handle_exception(e, level: :fatal, operation: :load_sequel_model, model: model)
-          raise e unless Legion::Settings[:data][:models][:continue_on_fail]
+          raise e unless Legion::Settings[:data][:models][:continue_on_load_fail]
         end
       end
     end

--- a/lib/legion/data/settings.rb
+++ b/lib/legion/data/settings.rb
@@ -48,8 +48,9 @@ module Legion
           sql_log_level:                 'debug',
 
           # Connection health (network adapters only, ignored for sqlite)
+          # -1 means validate on every checkout, catching stale connections from VPN/sleep/network changes immediately
           connection_validation:         true,
-          connection_validation_timeout: 600,
+          connection_validation_timeout: -1,
           connection_expiration:         true,
           connection_expiration_timeout: 14_400,
 

--- a/lib/legion/data/settings.rb
+++ b/lib/legion/data/settings.rb
@@ -35,7 +35,7 @@ module Legion
           # Connection pool
           max_connections:               25,
           pool_timeout:                  5,
-          preconnect:                    'concurrently',
+          preconnect:                    false,
           single_threaded:               false,
           test:                          true,
           name:                          nil,

--- a/lib/legion/data/version.rb
+++ b/lib/legion/data/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Data
-    VERSION = '1.6.26'
+    VERSION = '1.6.27'
   end
 end

--- a/lib/legion/data/version.rb
+++ b/lib/legion/data/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Data
-    VERSION = '1.6.25'
+    VERSION = '1.6.26'
   end
 end

--- a/spec/legion/data/audit_record_spec.rb
+++ b/spec/legion/data/audit_record_spec.rb
@@ -97,6 +97,22 @@ RSpec.describe Legion::Data::AuditRecord do
   # -------------------------------------------------------------------------
   # Integration — live SQLite database
   # -------------------------------------------------------------------------
+  # Temporarily disables the PG NO UPDATE/NO DELETE rules so tamper specs can
+  # directly corrupt rows. On non-PG adapters the rules don't exist and the
+  # block just yields directly.
+  def with_audit_records_writable(conn)
+    if Legion::Data::Connection.adapter == :postgres
+      conn.run('ALTER TABLE audit_records DISABLE RULE no_update_audit_records')
+      conn.run('ALTER TABLE audit_records DISABLE RULE no_delete_audit_records')
+    end
+    yield
+  ensure
+    if Legion::Data::Connection.adapter == :postgres
+      conn.run('ALTER TABLE audit_records ENABLE RULE no_update_audit_records')
+      conn.run('ALTER TABLE audit_records ENABLE RULE no_delete_audit_records')
+    end
+  end
+
   context 'with a live database', :aggregate_failures do
     before do
       Legion::Data::Connection.setup unless Legion::Data.connected?
@@ -176,16 +192,18 @@ RSpec.describe Legion::Data::AuditRecord do
         described_class.append(chain_id: chain_id, content_type: content_type,
                                content_hash: Digest::SHA256.hexdigest('r2'))
 
-        # Directly corrupt the first record's chain_hash (bypass immutability model guard).
-        # Use a per-test random value to avoid unique constraint collisions.
         tampered_hash = Digest::SHA256.hexdigest("tamper-#{chain_id}")
         first = Legion::Data.connection[:audit_records]
                             .where(chain_id: chain_id)
                             .order(:created_at, :id)
                             .first
-        Legion::Data.connection[:audit_records]
-                    .where(id: first[:id])
-                    .update(chain_hash: tampered_hash)
+
+        # PG NO UPDATE rule silently ignores Sequel updates; bypass via raw SQL.
+        with_audit_records_writable(Legion::Data.connection) do
+          Legion::Data.connection[:audit_records]
+                      .where(id: first[:id])
+                      .update(chain_hash: tampered_hash)
+        end
 
         result = described_class.verify(chain_id: chain_id)
         expect(result[:valid]).to be false
@@ -197,9 +215,11 @@ RSpec.describe Legion::Data::AuditRecord do
         r2 = described_class.append(chain_id: chain_id, content_type: content_type,
                                     content_hash: Digest::SHA256.hexdigest('r2'))
 
-        Legion::Data.connection[:audit_records]
-                    .where(id: r2[:id])
-                    .update(parent_hash: Digest::SHA256.hexdigest("tamper-parent-#{chain_id}"))
+        with_audit_records_writable(Legion::Data.connection) do
+          Legion::Data.connection[:audit_records]
+                      .where(id: r2[:id])
+                      .update(parent_hash: Digest::SHA256.hexdigest("tamper-parent-#{chain_id}"))
+        end
 
         result = described_class.verify(chain_id: chain_id)
         expect(result[:valid]).to be false

--- a/spec/legion/data/audit_record_spec.rb
+++ b/spec/legion/data/audit_record_spec.rb
@@ -98,7 +98,9 @@ RSpec.describe Legion::Data::AuditRecord do
   # Integration — live SQLite database
   # -------------------------------------------------------------------------
   context 'with a live database', :aggregate_failures do
-    before { skip 'No DB connection' unless Legion::Data.connected? }
+    before do
+      Legion::Data::Connection.setup unless Legion::Data.connected?
+    end
 
     describe '.append' do
       it 'inserts a record and returns chain metadata' do

--- a/spec/legion/data/connection_spec.rb
+++ b/spec/legion/data/connection_spec.rb
@@ -52,4 +52,10 @@ RSpec.describe 'Legion::Data::Connection' do
       .to eq Legion::Settings[:data][:log_warn_duration]
     expect(Legion::Data::Connection.sequel.sql_log_level).to eq Legion::Settings[:data][:sql_log_level].to_sym
   end
+
+  describe 'connection_validation_timeout default' do
+    it 'defaults to -1 so every checkout validates liveness' do
+      expect(Legion::Data::Settings.default[:connection_validation_timeout]).to eq(-1)
+    end
+  end
 end

--- a/spec/legion/data/connection_spec.rb
+++ b/spec/legion/data/connection_spec.rb
@@ -58,4 +58,10 @@ RSpec.describe 'Legion::Data::Connection' do
       expect(Legion::Data::Settings.default[:connection_validation_timeout]).to eq(-1)
     end
   end
+
+  describe 'preconnect default' do
+    it 'defaults to false to avoid background thread noise on failed network connects' do
+      expect(Legion::Data::Settings.default[:preconnect]).to eq(false)
+    end
+  end
 end

--- a/spec/legion/data/model_spec.rb
+++ b/spec/legion/data/model_spec.rb
@@ -5,6 +5,8 @@ require 'spec_helper'
 RSpec.describe Legion::Data::Models do
   after(:each) do
     Legion::Data::Connection.shutdown
+    Legion::Settings[:data][:models][:autoload] = true
+    Legion::Settings[:data][:models][:continue_on_load_fail] = false
   end
 
   it 'can load' do
@@ -21,6 +23,24 @@ RSpec.describe Legion::Data::Models do
   it '.load_sequel_model' do
     expect(Legion::Data::Models.load_sequel_model('task')).to eq 'task'
     expect { Legion::Data::Models.load_sequel_model('bad_model') }.to raise_exception LoadError
+  end
+
+  describe 'settings-driven behaviour' do
+    it 'respects autoload: false by skipping model loading' do
+      Legion::Settings[:data][:models][:autoload] = false
+      result = Legion::Data.load_models
+      expect(result).to be_nil
+    end
+
+    it 'uses continue_on_load_fail (not continue_on_fail) to swallow LoadError' do
+      Legion::Settings[:data][:models][:continue_on_load_fail] = true
+      expect { Legion::Data::Models.load_sequel_model('does_not_exist') }.not_to raise_error
+    end
+
+    it 'raises LoadError when continue_on_load_fail is false' do
+      Legion::Settings[:data][:models][:continue_on_load_fail] = false
+      expect { Legion::Data::Models.load_sequel_model('does_not_exist') }.to raise_error(LoadError)
+    end
   end
 
   it '.models' do


### PR DESCRIPTION
…detection

Closes #28

The previous default of 600s meant stale PG connections from a VPN drop, sleep/wake, or network interface change would not be detected for up to 10 minutes. -1 forces Sequel to validate every checkout so the connection pool immediately evicts dead connections and actors resume cleanly on the next tick after any network event.

## What

Brief description of the change.

## Why

What problem does this solve or what feature does it add?

## Checklist

- [ ] Tests pass (`bundle exec rspec`)
- [ ] RuboCop passes (`bundle exec rubocop`)
- [ ] CHANGELOG.md updated (if user-facing change)
- [ ] No new security concerns introduced
