### PR TITLE
feat: identity audit log table and multi-instance columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+## [1.7.0] - 2026-04-24
+
+### Added
+- Migration 072: `identity_audit_log` table (Postgres-only) with indexes
+- Migration 073: `employee_id` on principals, `account_type`/`qualifier`/`is_default`/`link_evidence` on identities, partial unique index for one-default-per-provider
+- `IdentityAuditLog` model added to model loader
+
 ## [1.6.30] - 2026-04-22
 
 ### Fixed

--- a/lib/legion/data/migrations/072_create_identity_audit_log.rb
+++ b/lib/legion/data/migrations/072_create_identity_audit_log.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    next unless adapter_scheme == :postgres
+
+    create_table(:identity_audit_log) do
+      column :id, :uuid, default: Sequel.lit('gen_random_uuid()'), primary_key: true
+      foreign_key :principal_id, :principals, type: :uuid, on_delete: :set_null
+      foreign_key :identity_id, :identities, type: :uuid, on_delete: :set_null
+      String :provider_name, null: false
+      String :event_type, null: false
+      String :trust_level
+      column :detail, :jsonb, null: false, default: Sequel.lit("'{}'")
+      String :node_id
+      String :session_id
+      DateTime :created_at, null: false, default: Sequel::CURRENT_TIMESTAMP
+    end
+
+    add_index :identity_audit_log, :principal_id
+    add_index :identity_audit_log, :event_type
+    add_index :identity_audit_log, :created_at
+    add_index :identity_audit_log, %i[principal_id event_type created_at]
+  end
+
+  down do
+    next unless adapter_scheme == :postgres
+
+    drop_table?(:identity_audit_log)
+  end
+end

--- a/lib/legion/data/migrations/073_add_identity_multi_instance_columns.rb
+++ b/lib/legion/data/migrations/073_add_identity_multi_instance_columns.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    next unless adapter_scheme == :postgres
+
+    alter_table(:principals) do
+      add_column :employee_id, String
+    end
+    run 'CREATE INDEX idx_principals_employee_id ON principals (employee_id) WHERE employee_id IS NOT NULL'
+
+    alter_table(:identities) do
+      add_column :account_type, String, null: false, default: 'primary'
+      add_column :qualifier, String
+      add_column :is_default, TrueClass, null: false, default: false
+      add_column :link_evidence, String
+    end
+
+    run 'CREATE UNIQUE INDEX identities_one_default_per_provider ON identities (principal_id, provider_id) WHERE is_default = true AND active = true'
+  end
+
+  down do
+    next unless adapter_scheme == :postgres
+
+    run 'DROP INDEX IF EXISTS identities_one_default_per_provider'
+
+    alter_table(:identities) do
+      drop_column :link_evidence
+      drop_column :is_default
+      drop_column :qualifier
+      drop_column :account_type
+    end
+
+    run 'DROP INDEX IF EXISTS idx_principals_employee_id'
+    alter_table(:principals) do
+      drop_column :employee_id
+    end
+  end
+end

--- a/lib/legion/data/model.rb
+++ b/lib/legion/data/model.rb
@@ -14,7 +14,7 @@ module Legion
           %w[extension function relationship chain task runner node setting digital_worker
              apollo_entry apollo_relation apollo_expertise apollo_access_log audit_log
              audit_record identity_provider principal identity identity_group
-             identity_group_membership]
+             identity_group_membership identity_audit_log]
         end
 
         def load

--- a/lib/legion/data/models/identity_audit_log.rb
+++ b/lib/legion/data/models/identity_audit_log.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+return unless Legion::Data::Connection.adapter == :postgres
+
+module Legion
+  module Data
+    module Model
+      class IdentityAuditLog < Sequel::Model(:identity_audit_log)
+        many_to_one :principal, class: 'Legion::Data::Model::Principal'
+        many_to_one :identity, class: 'Legion::Data::Model::Identity'
+      end
+    end
+  end
+end

--- a/lib/legion/data/version.rb
+++ b/lib/legion/data/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Data
-    VERSION = '1.6.30'
+    VERSION = '1.7.0'
   end
 end


### PR DESCRIPTION
## Summary
- Migration 072: `identity_audit_log` table (Postgres-only) with indexes on principal_id, event_type, created_at
- Migration 073: Adds `employee_id` to principals, adds `account_type`, `qualifier`, `is_default`, `link_evidence` to identities, partial unique index for one-default-per-provider
- New `IdentityAuditLog` model added to model loader

## Test plan
- [x] Rubocop: 0 offenses
- [ ] Run migrations against Postgres in infra mode
- [ ] Verify new tables and columns exist