### PR TITLE
fix(connection): make dev_fallback to SQLite loud, add health check methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+## [1.6.31] - 2026-04-27
+
+### Fixed
+- Dev-fallback to SQLite now logs at `:error` level (was `:warn`) with explicit warnings that data written to SQLite will NOT be visible when PostgreSQL reconnects — previously the fallback was nearly silent, causing Apollo knowledge entries and other DB-backed data to silently disappear when the connection state changed
+
+### Added
+- `Connection.connection_info` — returns adapter, connection state, and fallback status for health checks and diagnostics
+- `Connection.fallback_active?` — returns true when the data layer fell back to SQLite from a configured network database; Apollo and other services can check this to detect degraded mode and log appropriate warnings
+
+
 ## [1.6.29] - 2026-04-17
 
 ### Fixed

--- a/lib/legion/data/connection.rb
+++ b/lib/legion/data/connection.rb
@@ -163,8 +163,12 @@ module Legion
                       rescue StandardError => e
                         raise unless dev_fallback?
 
-                        handle_exception(e, level: :warn, handled: true, operation: :shared_connect, fallback: :sqlite)
+                        log.error("Legion::Data FALLING BACK TO SQLITE — PostgreSQL connection failed: #{e.message}")
+                        log.error('Legion::Data WARNING: Data written to SQLite will NOT be visible when PG reconnects. ' \
+                                  'Apollo knowledge, audit logs, and other DB-backed services will use a local-only store.')
+                        handle_exception(e, level: :error, handled: true, operation: :shared_connect, fallback: :sqlite)
                         @adapter = :sqlite
+                        @fallback_active = true
                         sqlite_opts = sequel_opts
                         ::Sequel.connect(sqlite_opts.merge(adapter: :sqlite, database: sqlite_path))
                       end
@@ -173,6 +177,25 @@ module Legion
           log_connection_info
           configure_extensions
           connect_with_replicas
+        end
+
+        # Returns connection metadata for health checks and diagnostics.
+        # Apollo and other services can use this to detect silent fallback.
+        def connection_info
+          {
+            adapter:          adapter,
+            connected:        Legion::Settings[:data][:connected],
+            fallback_active:  @fallback_active || false,
+            configured_adapter: Legion::Settings[:data][:adapter]&.to_sym || :sqlite,
+            sequel_alive:     (begin; @sequel&.test_connection; rescue StandardError; false; end)
+          }
+        end
+
+        # Returns true if the data layer fell back to SQLite from a configured
+        # network database (PostgreSQL/MySQL). Services should check this and
+        # log warnings when operating in degraded mode.
+        def fallback_active?
+          @fallback_active == true
         end
 
         def stats

--- a/lib/legion/data/version.rb
+++ b/lib/legion/data/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Data
-    VERSION = '1.6.29'
+    VERSION = '1.6.31'
   end
 end


### PR DESCRIPTION
## Problem

The dev_fallback from PostgreSQL to SQLite logged at `:warn` level — nearly silent. When it triggered, Apollo knowledge entries and other DB-backed data written to SQLite silently disappeared when the connection state changed back to PG (or vice versa). No way for services to detect they were in degraded/fallback mode.

## Fix

- Dev_fallback now logs at `:error` level with explicit warning that SQLite data will NOT be visible when PostgreSQL reconnects
- Tracks fallback state via `@fallback_active` instance variable
- `Connection.connection_info` — returns adapter, connection state, fallback status for diagnostics
- `Connection.fallback_active?` — Apollo and other services can detect degraded mode

## Version: 1.6.29 → 1.6.31