### PR TITLE
[codex] Stop query logger write storms after close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## [Unreleased]
 
+## [1.7.3] - 2026-04-27
+
+### Added
+- Migration 074: widens Apollo `content_hash` to 64 fixed characters and `knowledge_domain` / `source_provider` / `source_agent` to 255 characters so SHA-256 hashes and real-world identifiers fit without ingestion truncation failures. (Fixes #33, #34)
+- Migration 075: adds task `idempotency_key` and `idempotency_expires_at` columns plus indexes for SHA-256 payload deduplication windows. (Fixes #14)
+- Migration 076: adds `extract_step_timings` for per-step Extract pipeline timing visibility. (Fixes #15)
+- `Task.idempotency_key_for`, `Task.find_active_by_idempotency_key`, and `Task.create_idempotent` for stable content-addressed task dispatch deduplication. (Fixes #14)
+- Extract results now include `extract_id` and `step_timings`, and persist timing rows when the migration is present. (Fixes #15)
+- `AuditLogHashChain` plus `AuditLog.compute_hash` / `AuditLog.verify_chain` as the canonical data-side audit log hash-chain implementation for standard write paths to share. (Refs #13)
+
+### Fixed
+- Migration 051 now adds SQLite/MySQL `tasks.created_at` without a non-constant default before backfilling from `created`, allowing later migration specs and fresh SQLite databases to migrate cleanly.
+
 ## [1.7.2] - 2026-04-27
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+## [1.6.31] - 2026-04-27
+
+### Fixed
+- Dev-fallback to SQLite now logs at `:error` level (was `:warn`) with explicit warnings that data written to SQLite will NOT be visible when PostgreSQL reconnects — previously the fallback was nearly silent, causing Apollo knowledge entries and other DB-backed data to silently disappear when the connection state changed
+
+### Added
+- `Connection.connection_info` — returns adapter, connection state, and fallback status for health checks and diagnostics
+- `Connection.fallback_active?` — returns true when the data layer fell back to SQLite from a configured network database; Apollo and other services can check this to detect degraded mode and log appropriate warnings
+
+
 ## [1.6.29] - 2026-04-17
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [1.7.1] - 2026-04-27
+
+### Fixed
+- `QueryFileLogger` now treats writes after `close` as no-ops, preventing repeated `IOError: closed stream` warnings from late Sequel query callbacks during shutdown. (Fixes #35)
+
 ## [1.7.0] - 2026-04-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -139,11 +139,29 @@ MyMemoryTrace.all  # queries legionio_local.db, never the shared DB
 `Legion::Data::Extract` provides a handler registry for extracting text from documents, used by `lex-knowledge` for corpus ingestion:
 
 ```ruby
-text = Legion::Data::Extract.extract('/path/to/document.pdf')
-text = Legion::Data::Extract.extract('/path/to/data.csv')
+result = Legion::Data::Extract.extract('/path/to/document.pdf')
+text = result[:text]
+result[:step_timings] # per-step name, start_time, end_time, status, error, duration_ms
 ```
 
 Supported formats: `.txt`, `.md`, `.csv`, `.json`, `.jsonl`, `.html`, `.xlsx`, `.docx`, `.pdf`, `.pptx`, `.vtt`
+
+When migration 076 is present, Extract also persists the same per-step timing rows to `extract_step_timings`
+under the returned `extract_id`.
+
+### Task Idempotency
+
+`Task.idempotency_key_for` computes a stable SHA-256 key from canonical JSON payloads. `Task.create_idempotent`
+returns an existing non-terminal task for the same key inside the optional TTL window, or creates a new task
+with `idempotency_key` and `idempotency_expires_at` populated:
+
+```ruby
+task = Legion::Data::Model::Task.create_idempotent(
+  { status: 'pending', payload: Legion::JSON.dump(payload) },
+  payload: payload,
+  ttl: 300
+)
+```
 
 ### Filesystem Spool (Write Buffer)
 
@@ -343,6 +361,7 @@ Legion::Data.reload_static_cache
 | `Chain` | `chains` | Task execution chains |
 | `AuditLog` | `audit_log` | Tamper-evident audit trail with hash chain |
 | `AuditRecord` | `audit_records` | Structured audit records |
+| `ExtractStepTiming` | `extract_step_timings` | Per-step Extract pipeline timing metadata |
 | `RbacRoleAssignment` | `rbac_role_assignments` | RBAC principal -> role mappings |
 | `RbacRunnerGrant` | `rbac_runner_grants` | Per-runner permission grants |
 | `RbacCrossTeamGrant` | `rbac_cross_team_grants` | Cross-team access grants |
@@ -377,7 +396,7 @@ Apollo models require PostgreSQL with the `pgvector` extension. They are skipped
 
 ## Migrations
 
-71 numbered Sequel DSL migrations run automatically on startup (`auto_migrate: true`). Key milestones:
+76 numbered Sequel DSL migrations run automatically on startup (`auto_migrate: true`). Key milestones:
 
 | Range | What was added |
 |-------|---------------|
@@ -393,6 +412,7 @@ Apollo models require PostgreSQL with the `pgvector` extension. They are skipped
 | 050 | Critical indexes across 13 tables |
 | 058–067 | Audit records, chains, knowledge tiers, tool embedding cache, identity system (providers, principals, identities, groups) |
 | 068–071 | Entity type on audit records, principal on nodes, approval queue resume, engine on relationships |
+| 072–076 | Identity audit/multi-instance columns, Apollo identifier widening, task idempotency, Extract step timings |
 
 Run migrations standalone:
 

--- a/lib/legion/data.rb
+++ b/lib/legion/data.rb
@@ -16,6 +16,7 @@ require_relative 'data/helper'
 require_relative 'data/rls'
 require_relative 'data/extract'
 require_relative 'data/audit_record'
+require_relative 'data/audit_log_hash_chain'
 
 unless Legion::Logging::Helper.method_defined?(:handle_exception)
   module Legion

--- a/lib/legion/data/audit_log_hash_chain.rb
+++ b/lib/legion/data/audit_log_hash_chain.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require 'digest'
+require 'legion/json'
+require 'time'
+
+module Legion
+  module Data
+    module AuditLogHashChain
+      GENESIS_HASH = ('0' * 64).freeze
+      CANONICAL_FIELDS = %i[
+        principal_id action resource source status detail created_at previous_hash
+      ].freeze
+
+      class << self
+        def compute_hash(record)
+          Digest::SHA256.hexdigest(canonical_payload(record))
+        end
+
+        def verify(records)
+          previous_hash = GENESIS_HASH
+          records.each do |record|
+            return invalid(record, :parent_mismatch) unless value_for(record, :previous_hash).to_s == previous_hash
+
+            expected = compute_hash(record)
+            return invalid(record, :hash_mismatch) unless value_for(record, :record_hash).to_s == expected
+
+            previous_hash = expected
+          end
+
+          { valid: true, length: records.size }
+        end
+
+        def canonical_payload(record)
+          CANONICAL_FIELDS.map do |field|
+            "#{field}:#{canonical_value(value_for(record, field))}"
+          end.join('|')
+        end
+
+        private
+
+        def invalid(record, reason)
+          { valid: false, broken_at: value_for(record, :id), reason: reason }
+        end
+
+        def canonical_value(value)
+          case value
+          when Time
+            value.utc.iso8601(6)
+          when DateTime
+            value.to_time.utc.iso8601(6)
+          when Hash
+            Legion::JSON.dump(canonical_hash(value))
+          when Array
+            Legion::JSON.dump(value.map { |item| canonical_json_value(item) })
+          else
+            value.to_s
+          end
+        end
+
+        def canonical_json_value(value)
+          case value
+          when Hash then canonical_hash(value)
+          when Array then value.map { |item| canonical_json_value(item) }
+          else value
+          end
+        end
+
+        def canonical_hash(hash)
+          hash.keys.map(&:to_s).sort.to_h do |key|
+            [key, canonical_json_value(hash.fetch(key) { hash.fetch(key.to_sym) })]
+          end
+        end
+
+        def value_for(record, field)
+          return record[field] if record.respond_to?(:[]) && !record[field].nil?
+          return record[field.to_s] if record.respond_to?(:[]) && !record[field.to_s].nil?
+          return record.public_send(field) if record.respond_to?(field)
+
+          nil
+        end
+      end
+    end
+  end
+end

--- a/lib/legion/data/connection.rb
+++ b/lib/legion/data/connection.rb
@@ -103,12 +103,13 @@ module Legion
 
         def initialize(path)
           @path = path
+          @closed = false
+          @mutex = Mutex.new
           dir = File.dirname(path)
           FileUtils.mkdir_p(dir)
           FileUtils.chmod(0o700, dir) if File.directory?(dir)
           @file = File.open(path, File::WRONLY | File::APPEND | File::CREAT, 0o600)
           @file.sync = true
-          @mutex = Mutex.new
         end
 
         def debug(message)
@@ -128,16 +129,23 @@ module Legion
         end
 
         def close
-          @mutex.synchronize { @file.close unless @file.closed? }
+          @mutex.synchronize do
+            @closed = true
+            @file.close unless @file.closed?
+          end
         end
 
         private
 
         def write(level, message)
           @mutex.synchronize do
+            return if @closed || @file.closed?
+
             @file.puts "[#{Time.now.strftime('%Y-%m-%d %H:%M:%S.%L')}] #{level} #{message}"
           end
         rescue IOError => e
+          return nil if @closed || @file.closed?
+
           handle_exception(e, level: :warn, handled: true, operation: :query_file_write, path: @path)
           nil
         end

--- a/lib/legion/data/connection.rb
+++ b/lib/legion/data/connection.rb
@@ -163,8 +163,12 @@ module Legion
                       rescue StandardError => e
                         raise unless dev_fallback?
 
-                        handle_exception(e, level: :warn, handled: true, operation: :shared_connect, fallback: :sqlite)
+                        log.error("Legion::Data FALLING BACK TO SQLITE — PostgreSQL connection failed: #{e.message}")
+                        log.error('Legion::Data WARNING: Data written to SQLite will NOT be visible when PG reconnects. ' \
+                                  'Apollo knowledge, audit logs, and other DB-backed services will use a local-only store.')
+                        handle_exception(e, level: :error, handled: true, operation: :shared_connect, fallback: :sqlite)
                         @adapter = :sqlite
+                        @fallback_active = true
                         sqlite_opts = sequel_opts
                         ::Sequel.connect(sqlite_opts.merge(adapter: :sqlite, database: sqlite_path))
                       end
@@ -173,6 +177,25 @@ module Legion
           log_connection_info
           configure_extensions
           connect_with_replicas
+        end
+
+        # Returns connection metadata for health checks and diagnostics.
+        # Apollo and other services can use this to detect silent fallback.
+        def connection_info
+          {
+            adapter:          adapter,
+            connected:        Legion::Settings[:data][:connected],
+            fallback_active:  @fallback_active || false,
+            configured_adapter: Legion::Settings[:data][:adapter]&.to_sym || :sqlite,
+            sequel_alive:     (begin; @sequel&.test_connection; rescue StandardError; false; end)
+          }
+        end
+
+        # Returns true if the data layer fell back to SQLite from a configured
+        # network database (PostgreSQL/MySQL). Services should check this and
+        # log warnings when operating in degraded mode.
+        def fallback_active?
+          @fallback_active == true
         end
 
         def stats

--- a/lib/legion/data/extract.rb
+++ b/lib/legion/data/extract.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'legion/logging/helper'
+require 'securerandom'
 require_relative 'extract/type_detector'
 require_relative 'extract/handlers/base'
 
@@ -11,29 +12,49 @@ module Legion
         include Legion::Logging::Helper
 
         def extract(source, type: :auto)
-          detected_type = type == :auto ? TypeDetector.detect(source) : type&.to_sym
-          return { success: false, text: nil, error: :unknown_type } unless detected_type
+          extract_id = SecureRandom.uuid
+          timings = []
+          detected_type = timed_step(:detect_type, timings) do
+            type == :auto ? TypeDetector.detect(source) : type&.to_sym
+          end
+          unless detected_type
+            result = { success: false, text: nil, error: :unknown_type, extract_id: extract_id,
+                       step_timings: timings }
+            persist_step_timings(extract_id, timings)
+            return result
+          end
 
-          handler = Handlers::Base.for_type(detected_type)
-          return { success: false, text: nil, error: :no_handler, type: detected_type } unless handler
+          handler = timed_step(:resolve_handler, timings) { Handlers::Base.for_type(detected_type) }
+          unless handler
+            result = { success: false, text: nil, error: :no_handler, type: detected_type, extract_id: extract_id,
+                       step_timings: timings }
+            persist_step_timings(extract_id, timings)
+            return result
+          end
 
-          unless handler.available?
+          available = timed_step(:check_availability, timings) { handler.available? }
+          unless available
             return { success: false, text: nil, error: :gem_not_installed,
-                     gem: handler.gem_name, type: detected_type }
+                     gem: handler.gem_name, type: detected_type, extract_id: extract_id,
+                     step_timings: timings }.tap { persist_step_timings(extract_id, timings) }
           end
 
           log.info "Extract starting type=#{detected_type} handler=#{handler.name}"
-          result = handler.extract(source)
+          result = timed_step(:handler_extract, timings) { handler.extract(source) }
           if result[:text]
             log.info "Extract succeeded type=#{detected_type}"
-            { success: true, text: result[:text], metadata: result[:metadata], type: detected_type }
+            { success: true, text: result[:text], metadata: result[:metadata], type: detected_type,
+              extract_id: extract_id, step_timings: timings }
           else
             log.warn "Extract failed type=#{detected_type} error=#{result[:error]}"
-            { success: false, text: nil, error: result[:error], type: detected_type }
-          end
+            { success: false, text: nil, error: result[:error], type: detected_type,
+              extract_id: extract_id, step_timings: timings }
+          end.tap { persist_step_timings(extract_id, timings) }
         rescue StandardError => e
           handle_exception(e, level: :error, handled: true, operation: :extract, type: detected_type)
-          { success: false, text: nil, error: e.message, type: detected_type }
+          persist_step_timings(extract_id, timings) if extract_id
+          { success: false, text: nil, error: e.message, type: detected_type, extract_id: extract_id,
+            step_timings: timings }
         end
 
         def supported_types
@@ -53,6 +74,48 @@ module Legion
         end
 
         private
+
+        def timed_step(name, timings)
+          monotonic_start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          start_time = Time.now.utc
+          result = yield
+          record_step_timing(timings, name: name, start_time: start_time, monotonic_start: monotonic_start,
+                                      status: :success)
+          result
+        rescue StandardError => e
+          record_step_timing(timings, name: name, start_time: start_time, monotonic_start: monotonic_start,
+                                      status: :error, error: "#{e.class}: #{e.message}")
+          raise
+        end
+
+        def record_step_timing(timings, name:, start_time:, monotonic_start:, status:, error: nil)
+          end_time = Time.now.utc
+          duration_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - monotonic_start) * 1000).round
+          timings << {
+            name:        name.to_s,
+            start_time:  start_time,
+            end_time:    end_time,
+            status:      status.to_s,
+            error:       error,
+            duration_ms: duration_ms
+          }
+        end
+
+        def persist_step_timings(extract_id, timings)
+          return unless defined?(Legion::Data)
+
+          connection = Legion::Data.connection
+          return unless connection&.table_exists?(:extract_step_timings)
+
+          existing_steps = connection[:extract_step_timings].where(extract_id: extract_id).select_map(:name)
+          rows = timings.reject { |timing| existing_steps.include?(timing[:name]) }.map do |timing|
+            timing.merge(extract_id: extract_id)
+          end
+          connection[:extract_step_timings].multi_insert(rows) unless rows.empty?
+        rescue StandardError => e
+          handle_exception(e, level: :warn, handled: true, operation: :persist_extract_step_timings,
+                            extract_id: extract_id)
+        end
 
         def load_all_handlers
           return if @handlers_loaded

--- a/lib/legion/data/migrations/051_fix_tasks_created_at.rb
+++ b/lib/legion/data/migrations/051_fix_tasks_created_at.rb
@@ -14,7 +14,7 @@ Sequel.migration do
     else
       # SQLite/MySQL: add real column and backfill from created
       alter_table(:tasks) do
-        add_column :created_at, DateTime, default: Sequel::CURRENT_TIMESTAMP
+        add_column :created_at, DateTime
       end
 
       run 'UPDATE tasks SET created_at = created WHERE created_at IS NULL'

--- a/lib/legion/data/migrations/074_widen_apollo_entry_identifiers.rb
+++ b/lib/legion/data/migrations/074_widen_apollo_entry_identifiers.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    next unless adapter_scheme == :postgres
+    next unless table_exists?(:apollo_entries)
+
+    apollo_columns = schema(:apollo_entries).map(&:first)
+    alter_table(:apollo_entries) do
+      set_column_type :content_hash, String, fixed: true, size: 64 if apollo_columns.include?(:content_hash)
+      set_column_type :knowledge_domain, String, size: 255 if apollo_columns.include?(:knowledge_domain)
+      set_column_type :source_provider, String, size: 255 if apollo_columns.include?(:source_provider)
+      set_column_type :source_agent, String, size: 255 if apollo_columns.include?(:source_agent)
+    end
+
+    next unless table_exists?(:apollo_entries_archive)
+
+    archive_columns = schema(:apollo_entries_archive).map(&:first)
+    alter_table(:apollo_entries_archive) do
+      set_column_type :content_hash, String, fixed: true, size: 64 if archive_columns.include?(:content_hash)
+      set_column_type :knowledge_domain, String, size: 255 if archive_columns.include?(:knowledge_domain)
+      set_column_type :source_provider, String, size: 255 if archive_columns.include?(:source_provider)
+      set_column_type :source_agent, String, size: 255 if archive_columns.include?(:source_agent)
+    end
+  end
+
+  down do
+    next unless adapter_scheme == :postgres
+    next unless table_exists?(:apollo_entries)
+
+    apollo_columns = schema(:apollo_entries).map(&:first)
+    alter_table(:apollo_entries) do
+      set_column_type :content_hash, String, fixed: true, size: 32 if apollo_columns.include?(:content_hash)
+      set_column_type :knowledge_domain, String, size: 50 if apollo_columns.include?(:knowledge_domain)
+      set_column_type :source_provider, String, size: 50 if apollo_columns.include?(:source_provider)
+      set_column_type :source_agent, String, size: 50 if apollo_columns.include?(:source_agent)
+    end
+
+    next unless table_exists?(:apollo_entries_archive)
+
+    archive_columns = schema(:apollo_entries_archive).map(&:first)
+    alter_table(:apollo_entries_archive) do
+      set_column_type :content_hash, String, fixed: true, size: 32 if archive_columns.include?(:content_hash)
+      set_column_type :knowledge_domain, String, size: 50 if archive_columns.include?(:knowledge_domain)
+      set_column_type :source_provider, String, size: 50 if archive_columns.include?(:source_provider)
+      set_column_type :source_agent, String, size: 50 if archive_columns.include?(:source_agent)
+    end
+  end
+end

--- a/lib/legion/data/migrations/075_add_task_idempotency.rb
+++ b/lib/legion/data/migrations/075_add_task_idempotency.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    next unless table_exists?(:tasks)
+
+    existing_columns = schema(:tasks).map(&:first)
+    alter_table(:tasks) do
+      add_column :idempotency_key, String, size: 64 unless existing_columns.include?(:idempotency_key)
+      add_column :idempotency_expires_at, DateTime unless existing_columns.include?(:idempotency_expires_at)
+    end
+
+    add_index :tasks, :idempotency_key, name: :idx_tasks_idempotency_key, if_not_exists: true
+    add_index :tasks, :idempotency_expires_at, name: :idx_tasks_idempotency_expires_at, if_not_exists: true
+  end
+
+  down do
+    next unless table_exists?(:tasks)
+
+    existing_columns = schema(:tasks).map(&:first)
+    alter_table(:tasks) do
+      drop_index :idempotency_key, name: :idx_tasks_idempotency_key, if_exists: true
+      drop_index :idempotency_expires_at, name: :idx_tasks_idempotency_expires_at, if_exists: true
+      drop_column :idempotency_expires_at if existing_columns.include?(:idempotency_expires_at)
+      drop_column :idempotency_key if existing_columns.include?(:idempotency_key)
+    end
+  end
+end

--- a/lib/legion/data/migrations/076_create_extract_step_timings.rb
+++ b/lib/legion/data/migrations/076_create_extract_step_timings.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    create_table?(:extract_step_timings) do
+      primary_key :id
+      String :extract_id, size: 36, null: false
+      String :name, size: 100, null: false
+      DateTime :start_time, null: false
+      DateTime :end_time, null: false
+      String :status, size: 20, null: false
+      String :error, text: true
+      Integer :duration_ms, null: false, default: 0
+
+      index :extract_id, name: :idx_extract_step_timings_extract_id
+      index %i[extract_id name], name: :idx_extract_step_timings_extract_name
+      index :status, name: :idx_extract_step_timings_status
+    end
+  end
+
+  down do
+    drop_table?(:extract_step_timings)
+  end
+end

--- a/lib/legion/data/model.rb
+++ b/lib/legion/data/model.rb
@@ -14,7 +14,7 @@ module Legion
           %w[extension function relationship chain task runner node setting digital_worker
              apollo_entry apollo_relation apollo_expertise apollo_access_log audit_log
              audit_record identity_provider principal identity identity_group
-             identity_group_membership identity_audit_log]
+             identity_group_membership identity_audit_log extract_step_timing]
         end
 
         def load

--- a/lib/legion/data/models/audit_log.rb
+++ b/lib/legion/data/models/audit_log.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'legion/logging/helper'
+require 'legion/data/audit_log_hash_chain'
 
 module Legion
   module Data
@@ -32,6 +33,14 @@ module Legion
 
         def before_destroy
           raise 'audit_log records are immutable and cannot be deleted'
+        end
+
+        def self.compute_hash(record)
+          Legion::Data::AuditLogHashChain.compute_hash(record)
+        end
+
+        def self.verify_chain(records = order(:created_at, :id).all)
+          Legion::Data::AuditLogHashChain.verify(records)
         end
       end
     end

--- a/lib/legion/data/models/extract_step_timing.rb
+++ b/lib/legion/data/models/extract_step_timing.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Legion
+  module Data
+    module Model
+      class ExtractStepTiming < Sequel::Model(:extract_step_timings)
+      end
+    end
+  end
+end

--- a/lib/legion/data/models/task.rb
+++ b/lib/legion/data/models/task.rb
@@ -1,9 +1,17 @@
 # frozen_string_literal: true
 
+require 'digest'
+require 'legion/json'
+require 'time'
+
 module Legion
   module Data
     module Model
       class Task < Sequel::Model
+        TERMINAL_STATUSES = %w[
+          completed complete failed error cancelled canceled timeout timed_out
+        ].freeze
+
         many_to_one :relationship
         one_to_many :task_log
         many_to_one :parent, class: self
@@ -11,9 +19,51 @@ module Legion
         many_to_one :master, class: self
         one_to_many :slave, key: :master_id, class: self
 
+        def self.idempotency_key_for(payload)
+          Digest::SHA256.hexdigest(Legion::JSON.dump(canonical_payload(payload)))
+        end
+
+        def self.find_active_by_idempotency_key(key, now: Time.now)
+          return nil if key.to_s.empty?
+          return nil unless columns.include?(:idempotency_key)
+
+          where(idempotency_key: key)
+            .exclude(status: TERMINAL_STATUSES)
+            .where { (idempotency_expires_at =~ nil) | (idempotency_expires_at > now) }
+            .reverse_order(:created, :id)
+            .first
+        end
+
+        def self.create_idempotent(values, payload: nil, idempotency_key: nil, ttl: nil)
+          key = idempotency_key || idempotency_key_for(payload || values)
+          existing = find_active_by_idempotency_key(key)
+          return existing if existing
+
+          expires_at = ttl ? Time.now + ttl : nil
+          create(values.merge(idempotency_key: key, idempotency_expires_at: expires_at))
+        end
+
         def cancelled?
           !cancelled_at.nil?
         end
+
+        def self.canonical_payload(value)
+          case value
+          when Hash
+            value.keys.map(&:to_s).sort.to_h do |key|
+              [key, canonical_payload(value.fetch(key) { value.fetch(key.to_sym) })]
+            end
+          when Array
+            value.map { |item| canonical_payload(item) }
+          when Time
+            value.utc.iso8601(6)
+          when DateTime
+            value.to_time.utc.iso8601(6)
+          else
+            value
+          end
+        end
+        private_class_method :canonical_payload
       end
     end
   end

--- a/lib/legion/data/version.rb
+++ b/lib/legion/data/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Data
-    VERSION = '1.6.29'
+    VERSION = '1.6.31'
   end
 end

--- a/lib/legion/data/version.rb
+++ b/lib/legion/data/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Data
-    VERSION = '1.7.0'
+    VERSION = '1.7.1'
   end
 end

--- a/lib/legion/data/version.rb
+++ b/lib/legion/data/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Data
-    VERSION = '1.7.2'
+    VERSION = '1.7.3'
   end
 end

--- a/spec/legion/data/audit_log_hash_chain_spec.rb
+++ b/spec/legion/data/audit_log_hash_chain_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'legion/data/audit_log_hash_chain'
+
+RSpec.describe Legion::Data::AuditLogHashChain do
+  let(:created_at) { Time.utc(2026, 4, 27, 12, 0, 0) }
+  let(:record) do
+    {
+      id:            1,
+      principal_id:  'worker-1',
+      action:        'execute',
+      resource:      'runner#call',
+      source:        'amqp',
+      status:        'success',
+      detail:        '{"task_id":1}',
+      created_at:    created_at,
+      previous_hash: described_class::GENESIS_HASH
+    }
+  end
+
+  it 'computes deterministic canonical hashes' do
+    expect(described_class.compute_hash(record)).to eq(described_class.compute_hash(record.dup))
+    expect(described_class.compute_hash(record)).to match(/\A[0-9a-f]{64}\z/)
+  end
+
+  it 'verifies a valid chain' do
+    first = record.merge(record_hash: described_class.compute_hash(record))
+    second_base = record.merge(id: 2, action: 'finish', previous_hash: first[:record_hash])
+    second = second_base.merge(record_hash: described_class.compute_hash(second_base))
+
+    expect(described_class.verify([first, second])).to eq({ valid: true, length: 2 })
+  end
+
+  it 'detects parent mismatch' do
+    bad = record.merge(previous_hash: 'a' * 64, record_hash: 'b' * 64)
+    result = described_class.verify([bad])
+
+    expect(result[:valid]).to be false
+    expect(result[:reason]).to eq(:parent_mismatch)
+  end
+
+  it 'detects hash mismatch' do
+    bad = record.merge(record_hash: 'b' * 64)
+    result = described_class.verify([bad])
+
+    expect(result[:valid]).to be false
+    expect(result[:reason]).to eq(:hash_mismatch)
+  end
+end

--- a/spec/legion/data/connection_spec.rb
+++ b/spec/legion/data/connection_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'tmpdir'
 
 RSpec.describe 'Legion::Data::Connection' do
   after(:each) do
@@ -62,6 +63,29 @@ RSpec.describe 'Legion::Data::Connection' do
   describe 'preconnect default' do
     it 'defaults to false to avoid background thread noise on failed network connects' do
       expect(Legion::Data::Settings.default[:preconnect]).to eq(false)
+    end
+  end
+
+  describe Legion::Data::Connection::QueryFileLogger do
+    around do |example|
+      Dir.mktmpdir('legion-data-query-log') do |dir|
+        @query_log_path = File.join(dir, 'query.log')
+        example.run
+      end
+    end
+
+    it 'ignores debug writes after close without warning' do
+      logger = described_class.new(@query_log_path)
+      logger.close
+
+      expect(logger).not_to receive(:handle_exception)
+      expect { logger.debug('SELECT 1') }.not_to raise_error
+    end
+
+    it 'allows repeated close calls' do
+      logger = described_class.new(@query_log_path)
+
+      expect { 2.times { logger.close } }.not_to raise_error
     end
   end
 end

--- a/spec/legion/data/extract_spec.rb
+++ b/spec/legion/data/extract_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'spec_helper'
 require 'legion/data/extract'
 require 'legion/data/extract/handlers/text'
 require 'legion/data/extract/handlers/markdown'
@@ -15,6 +16,8 @@ RSpec.describe Legion::Data::Extract do
         result = described_class.extract('test string', type: :auto)
         expect(result[:success]).to be false
         expect(result[:error]).to eq(:unknown_type)
+        expect(result[:extract_id]).to match(/\A[0-9a-f-]{36}\z/)
+        expect(result[:step_timings].map { |step| step[:name] }).to include('detect_type')
       end
     end
 
@@ -61,6 +64,21 @@ RSpec.describe Legion::Data::Extract do
       expect(result[:success]).to be true
       expect(result[:text]).to eq('integration test')
       expect(result[:type]).to eq(:text)
+      expect(result[:step_timings].map { |step| step[:name] }).to include(
+        'detect_type', 'resolve_handler', 'check_availability', 'handler_extract'
+      )
+    ensure
+      f&.close!
+    end
+
+    it 'persists per-step timing metadata when the timing table is available' do
+      f = Tempfile.new(['test', '.txt'])
+      f.write('timed extraction')
+      f.flush
+      result = described_class.extract(f.path)
+      rows = Legion::Data.connection[:extract_step_timings].where(extract_id: result[:extract_id]).all
+      expect(rows.map { |row| row[:name] }).to include('handler_extract')
+      expect(rows.all? { |row| row[:status] == 'success' }).to be true
     ensure
       f&.close!
     end

--- a/spec/legion/data/models/audit_log_spec.rb
+++ b/spec/legion/data/models/audit_log_spec.rb
@@ -92,6 +92,24 @@ RSpec.describe Legion::Data::Model::AuditLog do
     end
   end
 
+  describe '.compute_hash' do
+    it 'delegates to the canonical audit log hash chain' do
+      record = valid_attrs.merge(previous_hash: Legion::Data::AuditLogHashChain::GENESIS_HASH)
+      expect(described_class.compute_hash(record)).to eq(Legion::Data::AuditLogHashChain.compute_hash(record))
+    end
+  end
+
+  describe '.verify_chain' do
+    it 'verifies records with the canonical hash chain' do
+      first_base = valid_attrs.merge(id: 1, previous_hash: Legion::Data::AuditLogHashChain::GENESIS_HASH)
+      first = first_base.merge(record_hash: described_class.compute_hash(first_base))
+      second_base = valid_attrs.merge(id: 2, action: 'archive', previous_hash: first[:record_hash])
+      second = second_base.merge(record_hash: described_class.compute_hash(second_base))
+
+      expect(described_class.verify_chain([first, second])).to eq({ valid: true, length: 2 })
+    end
+  end
+
   describe 'immutability' do
     it 'raises on update' do
       record = described_class.create(**valid_attrs)

--- a/spec/legion/data/models/tasks_spec.rb
+++ b/spec/legion/data/models/tasks_spec.rb
@@ -18,4 +18,33 @@ RSpec.describe Legion::Data::Model::Task do
   it { should respond_to? :user_owner }
   it { should respond_to? :group_owner }
   it { should be_a Sequel::Model }
+
+  describe '.idempotency_key_for' do
+    it 'returns the same SHA-256 key for hash payloads with different key order' do
+      left = described_class.idempotency_key_for({ b: 2, a: 1 })
+      right = described_class.idempotency_key_for({ a: 1, b: 2 })
+
+      expect(left).to eq(right)
+      expect(left).to match(/\A[0-9a-f]{64}\z/)
+    end
+  end
+
+  describe '.create_idempotent' do
+    it 'returns an existing active task for duplicate payloads' do
+      attrs = { status: 'pending', payload: '{"a":1}' }
+      first = described_class.create_idempotent(attrs, payload: { a: 1 })
+      second = described_class.create_idempotent(attrs, payload: { a: 1 })
+
+      expect(second.id).to eq(first.id)
+    end
+
+    it 'creates a new task after the prior idempotency key reaches terminal status' do
+      attrs = { status: 'pending', payload: '{"a":2}' }
+      first = described_class.create_idempotent(attrs, payload: { a: 2 })
+      first.update(status: 'completed')
+      second = described_class.create_idempotent(attrs, payload: { a: 2 })
+
+      expect(second.id).not_to eq(first.id)
+    end
+  end
 end

--- a/spec/migrations/074_widen_apollo_entry_identifiers_spec.rb
+++ b/spec/migrations/074_widen_apollo_entry_identifiers_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Migration 074: widen Apollo entry identifiers' do
+  let(:db) { Legion::Data::Connection.sequel }
+
+  before(:all) do
+    migration_path = File.expand_path('../../lib/legion/data/migrations', __dir__)
+    Sequel::Migrator.run(Legion::Data::Connection.sequel, migration_path, target: 74)
+  end
+
+  it 'migration file exists' do
+    migration_path = File.expand_path('../../lib/legion/data/migrations', __dir__)
+    expect(File.exist?(File.join(migration_path, '074_widen_apollo_entry_identifiers.rb'))).to be true
+  end
+
+  context 'when postgres', if: Legion::Data::Connection.adapter == :postgres do
+    let(:columns) { db.schema(:apollo_entries).to_h }
+
+    it 'widens content_hash to 64 fixed characters' do
+      expect(columns[:content_hash][:db_type]).to match(/char/i)
+      expect(columns[:content_hash][:max_length]).to eq(64)
+    end
+
+    it 'widens knowledge_domain to 255 characters' do
+      expect(columns[:knowledge_domain][:max_length]).to eq(255)
+    end
+
+    it 'widens source_provider to 255 characters' do
+      expect(columns[:source_provider][:max_length]).to eq(255)
+    end
+
+    it 'widens source_agent to 255 characters' do
+      expect(columns[:source_agent][:max_length]).to eq(255)
+    end
+  end
+
+  context 'when not postgres', unless: Legion::Data::Connection.adapter == :postgres do
+    it 'skips postgres-only apollo_entries changes' do
+      expect(db.table_exists?(:apollo_entries)).to be false
+    end
+  end
+end

--- a/spec/migrations/075_add_task_idempotency_spec.rb
+++ b/spec/migrations/075_add_task_idempotency_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Migration 075: add task idempotency' do
+  let(:db) { Legion::Data::Connection.sequel }
+
+  before(:all) do
+    migration_path = File.expand_path('../../lib/legion/data/migrations', __dir__)
+    Sequel::Migrator.run(Legion::Data::Connection.sequel, migration_path, target: 75)
+  end
+
+  it 'adds idempotency_key to tasks' do
+    expect(db.schema(:tasks).map(&:first)).to include(:idempotency_key)
+  end
+
+  it 'adds idempotency_expires_at to tasks' do
+    expect(db.schema(:tasks).map(&:first)).to include(:idempotency_expires_at)
+  end
+
+  it 'indexes idempotency_key' do
+    expect(db.indexes(:tasks)).to have_key(:idx_tasks_idempotency_key)
+  end
+
+  it 'indexes idempotency_expires_at' do
+    expect(db.indexes(:tasks)).to have_key(:idx_tasks_idempotency_expires_at)
+  end
+end

--- a/spec/migrations/076_create_extract_step_timings_spec.rb
+++ b/spec/migrations/076_create_extract_step_timings_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Migration 076: create extract step timings' do
+  let(:db) { Legion::Data::Connection.sequel }
+
+  before(:all) do
+    migration_path = File.expand_path('../../lib/legion/data/migrations', __dir__)
+    Sequel::Migrator.run(Legion::Data::Connection.sequel, migration_path, target: 76)
+  end
+
+  it 'creates extract_step_timings' do
+    expect(db.table_exists?(:extract_step_timings)).to be true
+  end
+
+  it 'has timing metadata columns' do
+    columns = db.schema(:extract_step_timings).map(&:first)
+    expect(columns).to include(:extract_id, :name, :start_time, :end_time, :status, :error, :duration_ms)
+  end
+
+  it 'indexes extract_id' do
+    expect(db.indexes(:extract_step_timings)).to have_key(:idx_extract_step_timings_extract_id)
+  end
+end


### PR DESCRIPTION
## Summary
- Makes QueryFileLogger close idempotent and treats writes after close as no-ops instead of warning repeatedly.
- Adds release batch fixes for Apollo ingestion schema width: widens `apollo_entries.content_hash` to 64 chars and Apollo source/domain identifiers to 255 chars. Fixes #33 and fixes #34.
- Adds task idempotency columns and `Task` helpers for SHA-256 canonical payload deduplication. Fixes #14.
- Adds Extract per-step timing capture, result metadata, persistence table, and model. Fixes #15.
- Adds the data-side canonical audit log hash-chain helper and `AuditLog.compute_hash` / `AuditLog.verify_chain` for the standard write path to share. Refs #13; the remaining lex-audit caller swap is cross-repo.
- Fixes SQLite/MySQL migration 051 by removing the non-constant `CURRENT_TIMESTAMP` column default before backfill.
- Bumps legion-data to 1.7.3 and updates README/CHANGELOG.

## Validation
- bundle exec rspec --format json --out tmp/rspec_results.json --format progress --out tmp/rspec_progress.txt
- bundle exec rubocop -A
- git diff --check
