### PR TITLE
fix(connection): make dev_fallback to SQLite loud, add health check methods

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,29 @@
+# Standard LegionIO pre-commit configuration
+# Install: pre-commit install
+# Manual:  pre-commit run --all-files
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-json
+        exclude: Gemfile\.lock
+      - id: check-merge-conflict
+
+  - repo: local
+    hooks:
+      - id: rubocop
+        name: RuboCop (autofix)
+        entry: scripts/pre-commit-rubocop.sh
+        language: script
+        types: [ruby]
+        pass_filenames: true
+
+      - id: ruby-syntax
+        name: Ruby syntax check
+        entry: ruby -c
+        language: system
+        types: [ruby]
+        pass_filenames: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+## [1.6.31] - 2026-04-27
+
+### Fixed
+- Dev-fallback to SQLite now logs at `:error` level (was `:warn`) with explicit warnings that data written to SQLite will NOT be visible when PostgreSQL reconnects — previously the fallback was nearly silent, causing Apollo knowledge entries and other DB-backed data to silently disappear when the connection state changed
+
+### Added
+- `Connection.connection_info` — returns adapter, connection state, and fallback status for health checks and diagnostics
+- `Connection.fallback_active?` — returns true when the data layer fell back to SQLite from a configured network database; Apollo and other services can check this to detect degraded mode and log appropriate warnings
+
+
 ## [1.6.29] - 2026-04-17
 
 ### Fixed

--- a/lib/legion/data/connection.rb
+++ b/lib/legion/data/connection.rb
@@ -163,8 +163,12 @@ module Legion
                       rescue StandardError => e
                         raise unless dev_fallback?
 
-                        handle_exception(e, level: :warn, handled: true, operation: :shared_connect, fallback: :sqlite)
+                        log.error("Legion::Data FALLING BACK TO SQLITE — PostgreSQL connection failed: #{e.message}")
+                        log.error('Legion::Data WARNING: Data written to SQLite will NOT be visible when PG reconnects. ' \
+                                  'Apollo knowledge, audit logs, and other DB-backed services will use a local-only store.')
+                        handle_exception(e, level: :error, handled: true, operation: :shared_connect, fallback: :sqlite)
                         @adapter = :sqlite
+                        @fallback_active = true
                         sqlite_opts = sequel_opts
                         ::Sequel.connect(sqlite_opts.merge(adapter: :sqlite, database: sqlite_path))
                       end
@@ -173,6 +177,25 @@ module Legion
           log_connection_info
           configure_extensions
           connect_with_replicas
+        end
+
+        # Returns connection metadata for health checks and diagnostics.
+        # Apollo and other services can use this to detect silent fallback.
+        def connection_info
+          {
+            adapter:          adapter,
+            connected:        Legion::Settings[:data][:connected],
+            fallback_active:  @fallback_active || false,
+            configured_adapter: Legion::Settings[:data][:adapter]&.to_sym || :sqlite,
+            sequel_alive:     (begin; @sequel&.test_connection; rescue StandardError; false; end)
+          }
+        end
+
+        # Returns true if the data layer fell back to SQLite from a configured
+        # network database (PostgreSQL/MySQL). Services should check this and
+        # log warnings when operating in degraded mode.
+        def fallback_active?
+          @fallback_active == true
         end
 
         def stats

--- a/lib/legion/data/version.rb
+++ b/lib/legion/data/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Data
-    VERSION = '1.6.29'
+    VERSION = '1.6.31'
   end
 end

--- a/scripts/pre-commit-rubocop.sh
+++ b/scripts/pre-commit-rubocop.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Pre-commit hook: run RuboCop with autofix on staged Ruby files.
+# Tries rubocop directly, then bundle exec. If the binary is truly
+# unavailable (exit 127 / crash / Prism conflict), warns and defers
+# to CI. If rubocop runs but reports offenses, fails the commit.
+set -uo pipefail
+
+run_rubocop() {
+  output=$("$@" -A --force-exclusion "${FILES[@]}" 2>&1)
+  rc=$?
+  if [ $rc -eq 0 ] || [ $rc -eq 1 ]; then
+    # rubocop ran successfully: 0 = clean, 1 = offenses found
+    echo "$output"
+    return $rc
+  fi
+  # exit > 1 means rubocop crashed / couldn't load
+  return 2
+}
+
+FILES=("$@")
+
+if run_rubocop rubocop; then
+  exit 0
+elif [ $? -eq 1 ]; then
+  echo "RuboCop found offenses that could not be auto-corrected."
+  exit 1
+fi
+
+if run_rubocop bundle exec rubocop; then
+  exit 0
+elif [ $? -eq 1 ]; then
+  echo "RuboCop found offenses that could not be auto-corrected."
+  exit 1
+fi
+
+echo "⚠  RuboCop not available locally (Prism conflict?) — CI will enforce."
+echo "   Run 'ruby -c' to at least verify syntax."
+ruby -c "$@" 2>&1 || exit 1
+exit 0

--- a/spec/legion/data/connection_info_spec.rb
+++ b/spec/legion/data/connection_info_spec.rb
@@ -3,10 +3,11 @@
 require 'spec_helper'
 require 'fileutils'
 
-RSpec.describe 'Legion::Data::Connection health check methods' do
+RSpec.describe Legion::Data::Connection do
   let(:test_db) { 'legionio_connection_info_test.db' }
 
   before(:each) do
+    @mutated_connection = false
     @saved_adapter = Legion::Settings[:data][:adapter]
     @saved_creds = Legion::Settings[:data][:creds].dup
     @saved_dev_mode = Legion::Settings[:data][:dev_mode]
@@ -18,10 +19,12 @@ RSpec.describe 'Legion::Data::Connection health check methods' do
   end
 
   after(:each) do
-    begin
-      described_class.shutdown
-    rescue StandardError
-      nil
+    if @mutated_connection
+      begin
+        described_class.shutdown
+      rescue StandardError
+        nil
+      end
     end
 
     described_class.instance_variable_set(:@adapter, @saved_ivar_adapter)
@@ -61,6 +64,7 @@ RSpec.describe 'Legion::Data::Connection health check methods' do
     end
 
     it 'returns true after a deterministic network adapter fallback' do
+      @mutated_connection = true
       described_class.instance_variable_set(:@adapter, nil)
       described_class.instance_variable_set(:@sequel, nil)
       described_class.instance_variable_set(:@fallback_active, false)

--- a/spec/legion/data/connection_info_spec.rb
+++ b/spec/legion/data/connection_info_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Legion::Data::Connection health check methods' do
+  describe '.connection_info' do
+    it 'returns a hash with adapter and connection state' do
+      info = Legion::Data::Connection.connection_info
+      expect(info).to be_a(Hash)
+      expect(info).to have_key(:adapter)
+      expect(info).to have_key(:connected)
+      expect(info).to have_key(:fallback_active)
+    end
+
+    it 'reports the current adapter' do
+      info = Legion::Data::Connection.connection_info
+      expect(%i[sqlite postgres mysql2]).to include(info[:adapter])
+    end
+
+    it 'reports consistent fallback state' do
+      info = Legion::Data::Connection.connection_info
+      # fallback_active should match the class method
+      expect(info[:fallback_active]).to eq(Legion::Data::Connection.fallback_active?)
+    end
+  end
+
+  describe '.fallback_active?' do
+    it 'returns a boolean' do
+      expect(Legion::Data::Connection.fallback_active?).to be(true).or be(false)
+    end
+
+    it 'returns true when configured adapter differs from actual' do
+      # In test environments without PG, fallback to SQLite is expected
+      configured = Legion::Settings[:data][:adapter]&.to_sym rescue nil
+      if configured == :postgres && Legion::Data::Connection.connection_info[:adapter] == :sqlite
+        expect(Legion::Data::Connection.fallback_active?).to eq(true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Problem

The dev fallback from a configured network database to SQLite was too quiet and hard to detect. When it triggered, DB-backed data written to SQLite was local-only and would not be visible after the primary database reconnected. The branch also needed review cleanup around the added pre-commit hooks and fallback diagnostics.

## Fix

- Logs dev fallback at error level with adapter-specific network DB wording.
- Tracks fallback state through `Connection.fallback_active?`.
- Adds `Connection.connection_info` for health checks and diagnostics.
- Resets fallback state on successful setup/shutdown and refreshes the configured adapter on each setup call.
- Fixes pre-commit hooks so RuboCop failures fail the hook and Ruby syntax checks cover every passed file.
- Updates README for version 1.7.4, 76 migrations, fallback diagnostics, model surface, and pre-commit workflow.
- Merges the branch current with `main` without force-pushing.

## Version

`1.7.4`

## Verification

- `bundle exec rspec --format json --out tmp/rspec_results.json --format progress --out tmp/rspec_progress.txt`
- `bundle exec rubocop -A`
