### PR TITLE
fix superclass mismatch for Identity on service startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [1.8.1] - 2026-05-07
+
+### Fixed
+- `TypeError: superclass mismatch for class Identity` on startup: moved `require_relative 'identity/model_helpers'` inside the `Identity < Sequel::Model(:identities)` class body so the Sequel superclass is established before `model_helpers.rb` reopens the constant.
+
 ## [1.8.0] - 2026-05-06
 
 ### Added

--- a/lib/legion/data/models/identity.rb
+++ b/lib/legion/data/models/identity.rb
@@ -1,13 +1,12 @@
 # frozen_string_literal: true
 
-require_relative 'identity/model_helpers'
-
 return unless Legion::Data::Connection.adapter == :postgres
 
 module Legion
   module Data
     module Model
       class Identity < Sequel::Model(:identities)
+        require_relative 'identity/model_helpers'
         include ModelHelpers
 
         many_to_one :principal, class: 'Legion::Data::Model::Principal'

--- a/lib/legion/data/version.rb
+++ b/lib/legion/data/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Data
-    VERSION = '1.8.0'
+    VERSION = '1.8.1'
   end
 end


### PR DESCRIPTION
## Summary

- Moves `require_relative 'identity/model_helpers'` inside the `Identity < Sequel::Model(:identities)` class body, after the postgres adapter guard
- Eliminates `TypeError: superclass mismatch for class Identity` on startup

## Root Cause

`model_helpers.rb` was required at the top of `identity.rb` before the postgres guard. Ruby defined `Identity` with implicit `Object` superclass when `model_helpers.rb` opened `class Identity`. Seconds later, `identity.rb` tried to define `class Identity < Sequel::Model(:identities)` — different superclass → `TypeError`.

## Test plan

- [ ] 575 specs, 0 failures
- [ ] Rubocop: 0 offenses
- [ ] Start LegionIO against Postgres — no `TypeError: superclass mismatch` on startup

Closes #40