### PR TITLE
ensure Local SQLite always connects independent of shared DB setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [1.8.2] - 2026-05-07
+
+### Fixed
+- `Legion::Data::Local` (SQLite) now always connects on startup regardless of shared DB outcome. `setup_local` is called in an `ensure` block so a failure in `connection_setup`, `migrate`, `load_models`, or `setup_cache` no longer silently skips Local initialization. Previously, any exception in those steps left Local disconnected with no log evidence, causing extensions like `lex-agentic-memory` to fall back to shared PG and hit `PG::InsufficientPrivilege` on every flush.
+- `setup_local` now logs at `INFO` level on success (`Legion::Data::Local connected to <path>`) matching the pattern of the shared connection, and at `ERROR` (previously `WARN`) on failure so the failure is not invisible.
+
 ## [1.8.1] - 2026-05-07
 
 ### Fixed

--- a/lib/legion/data.rb
+++ b/lib/legion/data.rb
@@ -48,8 +48,11 @@ module Legion
         migrate
         load_models
         setup_cache
-        setup_local
         log.info 'Legion::Data setup complete'
+      rescue StandardError => e
+        handle_exception(e, level: :warn, operation: :setup, handled: true)
+      ensure
+        setup_local
       end
 
       def connection_setup
@@ -200,8 +203,9 @@ module Legion
         return if Legion::Settings[:data].dig(:local, :enabled) == false
 
         Legion::Data::Local.setup
+        log.info "Legion::Data::Local connected to #{Legion::Data::Local.db_path}"
       rescue StandardError => e
-        handle_exception(e, level: :warn, operation: :setup_local)
+        handle_exception(e, level: :error, operation: :setup_local)
       end
     end
   end

--- a/lib/legion/data/version.rb
+++ b/lib/legion/data/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Data
-    VERSION = '1.8.1'
+    VERSION = '1.8.2'
   end
 end


### PR DESCRIPTION
## Summary

- `setup_local` moved into an `ensure` block in `Legion::Data.setup` so Local SQLite always initializes regardless of shared DB outcome
- Adds `INFO` log on Local connect success matching the shared DB pattern (`Legion::Data::Local connected to <path>`)
- Promotes `setup_local` failure logging from `WARN` to `ERROR` so failures are visible

## Problem

`Legion::Data::Local` was the last step in `Legion::Data.setup`. Any exception in `connection_setup`, `migrate`, `load_models`, or `setup_cache` silently skipped Local initialization with no log evidence. In `agent` mode (migrations skipped, non-infra), the sequence broke after `load_models` and Local never connected:

```
INFO Legion::Data setup starting
INFO Legion::Data::Connection setup adapter=postgres
INFO Connected to postgres://...
INFO Legion::Data migrations skipped (mode: agent, requires: infra)
INFO Loading Legion::Data::Models
INFO [Readiness] data is ready   ← setup_local never reached
```

Extensions like `lex-agentic-memory` that depend on Local then fell back to the shared PG connection and hit `PG::InsufficientPrivilege: ERROR: permission denied for table memory_traces` on every flush/shutdown cycle.

## Test plan

- [ ] `bundle exec rspec` — 0 failures
- [ ] `bundle exec rubocop` — 0 offenses
- [ ] Start daemon in agent mode, confirm `Legion::Data::Local connected to ~/.legionio/legionio_local.db` appears in logs
- [ ] Confirm `GET /api/stats` shows `data_local.connected: true`
- [ ] Confirm `PG::InsufficientPrivilege` WARN no longer fires on shutdown

Closes #42