### PR TITLE
remove duplicate Local connected log line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [1.8.3] - 2026-05-07
+
+### Fixed
+- Remove duplicate `Legion::Data::Local connected to` log line; `Local.setup` already emits it.
+
 ## [1.8.2] - 2026-05-07
 
 ### Changed

--- a/lib/legion/data.rb
+++ b/lib/legion/data.rb
@@ -54,7 +54,6 @@ module Legion
         return if Legion::Settings[:data].dig(:local, :enabled) == false
 
         Legion::Data::Local.setup
-        log.info "Legion::Data::Local connected to #{Legion::Data::Local.db_path}"
       rescue StandardError => e
         handle_exception(e, level: :fatal, operation: :setup_local)
         raise

--- a/lib/legion/data/version.rb
+++ b/lib/legion/data/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Data
-    VERSION = '1.8.2'
+    VERSION = '1.8.3'
   end
 end


### PR DESCRIPTION
`Local.setup` already logs `Legion::Data::Local connected to <path> (WAL mode, 30s busy_timeout)`. The redundant `log.info` added in #44's `setup_local` produces a second identical line on every startup.

## Test plan
- [ ] 575 specs, 0 failures
- [ ] Startup logs show exactly one `Legion::Data::Local connected to` line