### PR TITLE
Consolidate identity schema: drop legacy, rename portable to canonical

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+## [1.8.4] - 2026-05-08
+
+### Removed
+- Dropped legacy postgres-only identity tables (`principals`, `identity_providers`, `identities`, `identity_groups`, `identity_group_memberships`, `identity_audit_log`) via migration 098.
+- Removed `table_available?` guards from all identity model files — models load unconditionally.
+
+### Changed
+- Renamed `portable_identity_*` tables to canonical names (`identity_principals`, `identity_providers`, `identities`, `identity_groups`, `identity_group_memberships`, `identity_audit_log`, `identity_provider_capabilities`) via migration 099.
+- Updated all identity models to reference the new table names.
+
 ## [1.8.3] - 2026-05-07
 
 ### Removed

--- a/lib/legion/data/migrations/098_drop_legacy_identity_tables.rb
+++ b/lib/legion/data/migrations/098_drop_legacy_identity_tables.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    drop_table(:identity_audit_log) if table_exists?(:identity_audit_log)
+    drop_table(:identity_group_memberships) if table_exists?(:identity_group_memberships)
+    drop_table(:identity_groups) if table_exists?(:identity_groups)
+    drop_table(:identities) if table_exists?(:identities)
+
+    alter_table(:nodes) { drop_column :principal_id } if table_exists?(:nodes) && schema(:nodes).any? { |col, _| col == :principal_id }
+
+    drop_table(:principals) if table_exists?(:principals)
+    drop_table(:identity_providers) if table_exists?(:identity_providers)
+  end
+
+  down do
+    nil
+  end
+end

--- a/lib/legion/data/migrations/099_rename_portable_identity_tables.rb
+++ b/lib/legion/data/migrations/099_rename_portable_identity_tables.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    rename_table(:portable_identity_provider_capabilities, :identity_provider_capabilities)
+    rename_table(:portable_identity_audit_log, :identity_audit_log)
+    rename_table(:portable_identity_group_memberships, :identity_group_memberships)
+    rename_table(:portable_identity_groups, :identity_groups)
+    rename_table(:portable_identities, :identities)
+    rename_table(:portable_identity_principals, :identity_principals)
+    rename_table(:portable_identity_providers, :identity_providers)
+  end
+
+  down do
+    rename_table(:identity_providers, :portable_identity_providers)
+    rename_table(:identity_principals, :portable_identity_principals)
+    rename_table(:identities, :portable_identities)
+    rename_table(:identity_groups, :portable_identity_groups)
+    rename_table(:identity_group_memberships, :portable_identity_group_memberships)
+    rename_table(:identity_audit_log, :portable_identity_audit_log)
+    rename_table(:identity_provider_capabilities, :portable_identity_provider_capabilities)
+  end
+end

--- a/lib/legion/data/models/identity/audit_log.rb
+++ b/lib/legion/data/models/identity/audit_log.rb
@@ -2,13 +2,11 @@
 
 require_relative 'model_helpers'
 
-return unless Legion::Data::Model::Identity::ModelHelpers.table_available?(:portable_identity_audit_log)
-
 module Legion
   module Data
     module Model
       class Identity
-        class AuditLog < Sequel::Model(:portable_identity_audit_log)
+        class AuditLog < Sequel::Model(:identity_audit_log)
           include ModelHelpers
 
           many_to_one :principal, class: 'Legion::Data::Model::Identity::Principal'

--- a/lib/legion/data/models/identity/group.rb
+++ b/lib/legion/data/models/identity/group.rb
@@ -2,19 +2,17 @@
 
 require_relative 'model_helpers'
 
-return unless Legion::Data::Model::Identity::ModelHelpers.table_available?(:portable_identity_groups)
-
 module Legion
   module Data
     module Model
       class Identity
-        class Group < Sequel::Model(:portable_identity_groups)
+        class Group < Sequel::Model(:identity_groups)
           include ModelHelpers
 
           one_to_many :memberships, class: 'Legion::Data::Model::Identity::GroupMembership', key: :group_id
           many_to_many :principals,
                        class:      'Legion::Data::Model::Identity::Principal',
-                       join_table: :portable_identity_group_memberships,
+                       join_table: :identity_group_memberships,
                        left_key:   :group_id,
                        right_key:  :principal_id
 

--- a/lib/legion/data/models/identity/group_memberships.rb
+++ b/lib/legion/data/models/identity/group_memberships.rb
@@ -2,13 +2,11 @@
 
 require_relative 'model_helpers'
 
-return unless Legion::Data::Model::Identity::ModelHelpers.table_available?(:portable_identity_group_memberships)
-
 module Legion
   module Data
     module Model
       class Identity
-        class GroupMembership < Sequel::Model(:portable_identity_group_memberships)
+        class GroupMembership < Sequel::Model(:identity_group_memberships)
           include ModelHelpers
 
           many_to_one :principal, class: 'Legion::Data::Model::Identity::Principal'

--- a/lib/legion/data/models/identity/identity.rb
+++ b/lib/legion/data/models/identity/identity.rb
@@ -2,13 +2,11 @@
 
 require_relative 'model_helpers'
 
-return unless Legion::Data::Model::Identity::ModelHelpers.table_available?(:portable_identities)
-
 module Legion
   module Data
     module Model
       class Identity
-        class Identity < Sequel::Model(:portable_identities)
+        class Identity < Sequel::Model(:identities)
           include ModelHelpers
 
           many_to_one :principal, class: 'Legion::Data::Model::Identity::Principal'

--- a/lib/legion/data/models/identity/model_helpers.rb
+++ b/lib/legion/data/models/identity/model_helpers.rb
@@ -11,12 +11,6 @@ module Legion
             model.extend(ClassMethods)
           end
 
-          def self.table_available?(table_name)
-            Legion::Data::Connection.sequel&.table_exists?(table_name)
-          rescue StandardError
-            false
-          end
-
           module ClassMethods
             def lookup(value)
               lookup_by_columns(value, lookup_columns)

--- a/lib/legion/data/models/identity/principal.rb
+++ b/lib/legion/data/models/identity/principal.rb
@@ -2,20 +2,18 @@
 
 require_relative 'model_helpers'
 
-return unless Legion::Data::Model::Identity::ModelHelpers.table_available?(:portable_identity_principals)
-
 module Legion
   module Data
     module Model
       class Identity
-        class Principal < Sequel::Model(:portable_identity_principals)
+        class Principal < Sequel::Model(:identity_principals)
           include ModelHelpers
 
           one_to_many :identities, class: 'Legion::Data::Model::Identity::Identity'
           one_to_many :group_memberships, class: 'Legion::Data::Model::Identity::GroupMembership'
           many_to_many :groups,
                        class:      'Legion::Data::Model::Identity::Group',
-                       join_table: :portable_identity_group_memberships,
+                       join_table: :identity_group_memberships,
                        left_key:   :principal_id,
                        right_key:  :group_id
 

--- a/lib/legion/data/models/identity/providers.rb
+++ b/lib/legion/data/models/identity/providers.rb
@@ -2,13 +2,11 @@
 
 require_relative 'model_helpers'
 
-return unless Legion::Data::Model::Identity::ModelHelpers.table_available?(:portable_identity_providers)
-
 module Legion
   module Data
     module Model
       class Identity
-        class Provider < Sequel::Model(:portable_identity_providers)
+        class Provider < Sequel::Model(:identity_providers)
           include ModelHelpers
 
           one_to_many :identities, class: 'Legion::Data::Model::Identity::Identity', key: :provider_id
@@ -25,7 +23,7 @@ module Legion
           end
         end
 
-        class ProviderCapability < Sequel::Model(:portable_identity_provider_capabilities)
+        class ProviderCapability < Sequel::Model(:identity_provider_capabilities)
           many_to_one :provider, class: 'Legion::Data::Model::Identity::Provider'
         end
       end

--- a/lib/legion/data/version.rb
+++ b/lib/legion/data/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Data
-    VERSION = '1.8.3'
+    VERSION = '1.8.4'
   end
 end


### PR DESCRIPTION
## Summary
- Migration 098: drops legacy postgres-only identity tables (principals, identity_providers, identities, identity_groups, identity_group_memberships, identity_audit_log)
- Migration 099: renames portable_identity_* tables to canonical names (identities, identity_principals, identity_providers, identity_groups, identity_group_memberships, identity_audit_log, identity_provider_capabilities)
- Removes table_available? guards from all identity model files
- Updates all model Sequel::Model declarations to reference new table names

## Test plan
- [x] `bundle exec rspec` — 575 examples, 0 failures
- [x] `bundle exec rubocop` — 0 offenses