### PR TITLE
Remove unnecessary defined?(Legion::Logging) guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Legion::Data Changelog
 
-## [Unreleased]
+## [1.8.5] - 2026-05-09
+
+### Removed
+- Unnecessary `defined?(Legion::Logging)` guards from connection and local database setup — legion-logging is a hard gemspec dependency and always available
 
 ## [1.8.4] - 2026-05-08
 

--- a/lib/legion/data/connection.rb
+++ b/lib/legion/data/connection.rb
@@ -396,7 +396,7 @@ module Legion
             opts[:logger]              = @query_file_logger
             opts[:sql_log_level]       = :debug
             opts[:log_connection_info] = data[:log_connection_info] || false
-          elsif data[:log] && defined?(Legion::Logging)
+          elsif data[:log]
             # Standard mode: slow-query warnings through Legion::Logging domain
             opts[:logger]              = build_data_logger
             opts[:sql_log_level]       = data[:sql_log_level]&.to_sym || :debug

--- a/lib/legion/data/local.rb
+++ b/lib/legion/data/local.rb
@@ -38,7 +38,7 @@ module Legion
             @query_file_logger = Legion::Data::Connection::QueryFileLogger.new(log_path)
             opts[:logger]          = @query_file_logger
             opts[:sql_log_level]   = :debug
-          elsif data[:log] && defined?(Legion::Logging)
+          elsif data[:log]
             opts[:logger]          = build_local_logger
             opts[:sql_log_level]   = resolved_sql_log_level
             opts[:log_warn_duration] = resolved_log_warn_duration

--- a/lib/legion/data/version.rb
+++ b/lib/legion/data/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Data
-    VERSION = '1.8.4'
+    VERSION = '1.8.5'
   end
 end


### PR DESCRIPTION
## Summary

- Removed `&& defined?(Legion::Logging)` from conditional checks in `lib/legion/data/connection.rb` (line 399) and `lib/legion/data/local.rb` (line 41)
- `legion-logging` is a hard gemspec dependency of `legion-data`, so `Legion::Logging` is always defined — these guards were dead code

## Test plan

- [x] `bundle exec rspec` — 575 examples, 0 failures
- [x] `bundle exec rubocop` — 257 files inspected, no offenses