### PR TITLE
fix(connection): implement reconnect_with_fresh_creds for Vault dynamic PG credential rotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Legion::Data Changelog
 
+## [1.8.8] - 2026-05-20
+
+### Added
+- `Legion::Data::Connection.reconnect_with_fresh_creds` — updates Sequel's internal connection opts with fresh credentials from `Legion::Settings[:data][:creds]` and reconnects the pool. Called by `LeaseManager#trigger_postgresql_reconnect` after Vault dynamic PostgreSQL lease rotation.
+
+### Fixed
+- Vault dynamic PostgreSQL credential rotation: after lease expiry, connections would fail with `PG::ConnectionBad: role "v-legionio-node-..." does not exist` because Sequel retained the original (revoked) credentials in `@opts`. The legacy fallback (`disconnect` + `test_connection`) was insufficient since it doesn't update stored credentials.
+
 ## [1.8.7] - 2026-05-17
 
 ### Added

--- a/lib/legion/data/connection.rb
+++ b/lib/legion/data/connection.rb
@@ -267,6 +267,36 @@ module Legion
           log.info 'Legion::Data connection closed'
         end
 
+        def reconnect_with_fresh_creds
+          return false unless @sequel
+          return false if adapter == :sqlite
+
+          fresh_creds = Legion::Settings[:data][:creds]
+          return false unless fresh_creds.is_a?(Hash)
+
+          new_user = fresh_creds[:user] || fresh_creds[:username]
+          new_pass = fresh_creds[:password]
+
+          unless new_user && new_pass
+            log.error('reconnect_with_fresh_creds: no user/password in Settings[:data][:creds]')
+            return false
+          end
+
+          old_user = @sequel.opts[:user]
+          @sequel.opts[:user] = new_user
+          @sequel.opts[:password] = new_pass
+
+          @sequel.disconnect
+
+          @sequel.test_connection
+          log.info("reconnect_with_fresh_creds: rotated credentials (#{old_user} → #{new_user})")
+          true
+        rescue StandardError => e
+          handle_exception(e, level: :error, handled: true, operation: :reconnect_with_fresh_creds,
+                           old_user: old_user, new_user: new_user)
+          false
+        end
+
         def connect_with_replicas
           return unless adapter == :postgres
 

--- a/lib/legion/data/version.rb
+++ b/lib/legion/data/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Data
-    VERSION = '1.8.7'
+    VERSION = '1.8.8'
   end
 end

--- a/spec/legion/data/connection_reconnect_spec.rb
+++ b/spec/legion/data/connection_reconnect_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Legion::Data::Connection.reconnect_with_fresh_creds' do
+  after(:each) do
+    Legion::Data::Connection.shutdown
+  end
+
+  context 'when adapter is sqlite' do
+    let(:mock_sequel) { instance_double(Sequel::SQLite::Database, opts: {}) }
+
+    it 'returns false (no-op for sqlite)' do
+      Legion::Data::Connection.instance_variable_set(:@sequel, mock_sequel)
+      Legion::Data::Connection.instance_variable_set(:@adapter, :sqlite)
+      expect(Legion::Data::Connection.reconnect_with_fresh_creds).to be false
+    end
+
+    after do
+      Legion::Data::Connection.instance_variable_set(:@adapter, nil)
+      Legion::Data::Connection.instance_variable_set(:@sequel, nil)
+    end
+  end
+
+  context 'when sequel is nil' do
+    it 'returns false' do
+      Legion::Data::Connection.instance_variable_set(:@sequel, nil)
+      expect(Legion::Data::Connection.reconnect_with_fresh_creds).to be false
+    end
+  end
+
+  context 'with a postgres adapter (mocked)' do
+    let(:mock_sequel) do
+      instance_double(Sequel::Database, opts: { user: 'old-vault-user', password: 'old-pass' })
+    end
+
+    before do
+      Legion::Data::Connection.instance_variable_set(:@sequel, mock_sequel)
+      Legion::Data::Connection.instance_variable_set(:@adapter, :postgres)
+    end
+
+    after do
+      Legion::Data::Connection.instance_variable_set(:@adapter, nil)
+      Legion::Data::Connection.instance_variable_set(:@sequel, nil)
+    end
+
+    it 'updates sequel opts and reconnects with fresh creds' do
+      Legion::Settings[:data][:creds] = { user: 'new-vault-user', password: 'new-pass', host: '127.0.0.1', port: 5432 }
+
+      allow(mock_sequel).to receive(:disconnect)
+      allow(mock_sequel).to receive(:test_connection).and_return(true)
+
+      result = Legion::Data::Connection.reconnect_with_fresh_creds
+
+      expect(result).to be true
+      expect(mock_sequel.opts[:user]).to eq('new-vault-user')
+      expect(mock_sequel.opts[:password]).to eq('new-pass')
+      expect(mock_sequel).to have_received(:disconnect)
+      expect(mock_sequel).to have_received(:test_connection)
+    end
+
+    it 'handles :username key as fallback' do
+      Legion::Settings[:data][:creds] = { username: 'alt-user', password: 'alt-pass' }
+
+      allow(mock_sequel).to receive(:disconnect)
+      allow(mock_sequel).to receive(:test_connection).and_return(true)
+
+      result = Legion::Data::Connection.reconnect_with_fresh_creds
+
+      expect(result).to be true
+      expect(mock_sequel.opts[:user]).to eq('alt-user')
+    end
+
+    it 'returns false when creds lack user/password' do
+      Legion::Settings[:data][:creds] = { host: '127.0.0.1' }
+
+      expect(Legion::Data::Connection.reconnect_with_fresh_creds).to be false
+    end
+
+    it 'returns false when creds is not a hash' do
+      Legion::Settings[:data][:creds] = nil
+
+      expect(Legion::Data::Connection.reconnect_with_fresh_creds).to be false
+    end
+
+    it 'returns false and handles exception when test_connection fails' do
+      Legion::Settings[:data][:creds] = { user: 'new-user', password: 'new-pass' }
+
+      allow(mock_sequel).to receive(:disconnect)
+      allow(mock_sequel).to receive(:test_connection).and_raise(Sequel::DatabaseConnectionError.new('connection refused'))
+
+      result = Legion::Data::Connection.reconnect_with_fresh_creds
+
+      expect(result).to be false
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Implements `Legion::Data::Connection.reconnect_with_fresh_creds` — the method `LeaseManager#trigger_postgresql_reconnect` expects after rotating a dynamic Vault PostgreSQL lease
- Updates Sequel's internal `@opts[:user]` and `@opts[:password]` with fresh credentials from `Legion::Settings[:data][:creds]`, then disconnects the pool so new connections use the rotated Vault role
- Without this, lease expiry causes `PG::ConnectionBad: role "v-legionio-node-..." does not exist` on all DB operations until restart

## Test plan

- [x] 7 new specs in `spec/legion/data/connection_reconnect_spec.rb` — all pass
- [x] RuboCop clean
- [ ] Integration: verify with live Vault dynamic PG creds that rotation survives lease TTL boundary

Closes #51