### PR TITLE
feat: add llm_skill_events table as core LLM lifecycle table (migrati…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Legion::Data Changelog
 
+## [1.10.0] - 2026-06-01
+
+### Added
+
+- Migration 129: creates `llm_skill_events` table as a core LLM lifecycle table (moved from lex-llm-ledger extension). Columns: `uuid`, `conversation_id`, `request_ref`, `skill_name`, `skill_version`, `trigger`, `status`, `duration_ms`, `identity_canonical_name`, `identity_principal_id`, `identity_id`, `schema_version`, `recorded_at`, `inserted_at`. Indexes on `conversation_id`, `request_ref`, `skill_name`, `identity_canonical_name`, `recorded_at`, `inserted_at`.
+
 ## [1.9.0] - 2026-06-01
 
 ### Added

--- a/lib/legion/data/migrations/129_create_llm_skill_events.rb
+++ b/lib/legion/data/migrations/129_create_llm_skill_events.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    create_table(:llm_skill_events) do
+      primary_key :id
+
+      String   :uuid, null: false, unique: true, size: 36
+      Integer  :conversation_id
+      String   :request_ref
+      String   :skill_name, null: false
+      String   :skill_version
+      String   :trigger
+      String   :status, null: false, default: 'completed'
+      Integer  :duration_ms, default: 0
+      String   :identity_canonical_name
+      Integer  :identity_principal_id
+      Integer  :identity_id
+      Integer  :schema_version, null: false, default: 15
+      DateTime :recorded_at, null: false
+      DateTime :inserted_at, null: false, default: Sequel::CURRENT_TIMESTAMP
+
+      index [:conversation_id]
+      index [:request_ref]
+      index [:skill_name]
+      index [:identity_canonical_name]
+      index [:recorded_at]
+      index [:inserted_at]
+    end
+  end
+
+  down do
+    drop_table :llm_skill_events
+  end
+end

--- a/lib/legion/data/migrations/129_create_llm_skill_events.rb
+++ b/lib/legion/data/migrations/129_create_llm_skill_events.rb
@@ -6,26 +6,19 @@ Sequel.migration do
       primary_key :id
 
       String   :uuid, null: false, unique: true, size: 36
-      Integer  :conversation_id
-      String   :request_ref
-      String   :skill_name, null: false
+      Integer  :conversation_id, index: true
+      String   :request_ref, index: true
+      String   :skill_name, null: false, index: true
       String   :skill_version
       String   :trigger
       String   :status, null: false, default: 'completed'
       Integer  :duration_ms, default: 0
-      String   :identity_canonical_name
+      String   :identity_canonical_name, index: true
       Integer  :identity_principal_id
       Integer  :identity_id
       Integer  :schema_version, null: false, default: 15
-      DateTime :recorded_at, null: false
-      DateTime :inserted_at, null: false, default: Sequel::CURRENT_TIMESTAMP
-
-      index [:conversation_id]
-      index [:request_ref]
-      index [:skill_name]
-      index [:identity_canonical_name]
-      index [:recorded_at]
-      index [:inserted_at]
+      DateTime :recorded_at, null: false, index: true
+      DateTime :inserted_at, null: false, default: Sequel::CURRENT_TIMESTAMP, index: true
     end
   end
 

--- a/lib/legion/data/version.rb
+++ b/lib/legion/data/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Data
-    VERSION = '1.9.0'
+    VERSION = '1.10.0'
   end
 end


### PR DESCRIPTION
…on 129)

Moves llm_skill_events from lex-llm-ledger extension into legion-data as a core table. This ensures all LLM lifecycle tables are owned by legion-data, eliminating cross-repo migration conflicts.

## What

Brief description of the change.

## Why

What problem does this solve or what feature does it add?

## Checklist

- [ ] Tests pass (`bundle exec rspec`)
- [ ] RuboCop passes (`bundle exec rubocop`)
- [ ] CHANGELOG.md updated (if user-facing change)
- [ ] No new security concerns introduced
