### PR TITLE
feat: add missing columns for lex-llm-ledger official writer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Legion::Data Changelog
 
+## [1.10.1] - 2026-06-01
+
+### Added
+
+- Migration 130: adds `pii_types_json` (TEXT), `jurisdictions_json` (TEXT), and `schema_version` (Integer, default 15) to `llm_conversations`. Required by lex-llm-ledger OfficialRecordWriter for compliance metadata.
+- Migration 131: adds `schema_version` (Integer, default 15) to `llm_tool_calls`. Required by lex-llm-ledger OfficialRecordWriter.
+
 ## [1.10.0] - 2026-06-01
 
 ### Added

--- a/lib/legion/data/migrations/130_add_llm_conversations_compliance_columns.rb
+++ b/lib/legion/data/migrations/130_add_llm_conversations_compliance_columns.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    alter_table(:llm_conversations) do
+      add_column :pii_types_json, :text, null: true
+      add_column :jurisdictions_json, :text, null: true
+      add_column :schema_version, Integer, null: false, default: 15
+    end
+  end
+
+  down do
+    alter_table(:llm_conversations) do
+      drop_column :schema_version
+      drop_column :jurisdictions_json
+      drop_column :pii_types_json
+    end
+  end
+end

--- a/lib/legion/data/migrations/131_add_llm_tool_calls_schema_version.rb
+++ b/lib/legion/data/migrations/131_add_llm_tool_calls_schema_version.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    alter_table(:llm_tool_calls) do
+      add_column :schema_version, Integer, null: false, default: 15
+    end
+  end
+
+  down do
+    alter_table(:llm_tool_calls) do
+      drop_column :schema_version
+    end
+  end
+end

--- a/lib/legion/data/version.rb
+++ b/lib/legion/data/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Data
-    VERSION = '1.10.0'
+    VERSION = '1.10.1'
   end
 end


### PR DESCRIPTION
## Summary
- Migration 130: adds `pii_types_json`, `jurisdictions_json`, and `schema_version` to `llm_conversations`
- Migration 131: adds `schema_version` to `llm_tool_calls`
- These columns are written by `OfficialRecordWriter` in lex-llm-ledger and were causing 52 test failures (`table has no column named pii_types_json` / `schema_version`)

## Test plan
- [x] `bundle exec rspec` — 432 examples, 0 failures
- [x] `bundle exec rubocop -A` — 270 files, 0 offenses
- [ ] lex-llm-ledger CI passes after bumping legion-data dependency