### PR TITLE
feat(schema): context token accounting columns and events table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Legion::Data Changelog
 
+## [1.10.4] - 2026-06-12
+
+### Added
+- Migration 134: adds `operation` (String 64), `dispatch_path` (String 32), and `idempotency_key` (String 128) columns to `llm_route_attempts` with indexes on `operation` and `idempotency_key`. Enables per-attempt tracking of the LLM operation type, routing path, and deduplication key.
+
 ## [1.10.3] - 2026-06-10
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Legion::Data Changelog
 
+## [1.10.5] - 2026-06-16
+
+### Added
+- Migration 135: adds context token accounting columns to `llm_message_inference_metrics` — `llm_message_inference_metrics` is now the canonical source of truth for all pipeline context token metrics (request messages, loaded/curated/archived history, thinking strip savings, context-window enforcement savings, RAG injection, system/baseline prompt, tool definitions, final context estimate). Includes `context_accounting_status` and `context_accounting_json` for provenance.
+- Migration 135: creates `llm_context_accounting_events` table for drill-down evidence rows (not a second source of token truth — totals reconcile to the canonical metrics row).
+- Model: `Legion::Data::Models::LLM::ContextAccountingEvent` with foreign key associations to request, response, and metric.
+- Association: `MessageInferenceMetric#context_accounting_events`.
+
 ## [1.10.4] - 2026-06-12
 
 ### Added

--- a/lib/legion/data/migrations/135_add_llm_context_token_accounting.rb
+++ b/lib/legion/data/migrations/135_add_llm_context_token_accounting.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    alter_table(:llm_message_inference_metrics) do
+      add_column :request_message_estimated_tokens, Integer, null: false, default: 0
+      add_column :loaded_history_estimated_tokens, Integer, null: false, default: 0
+      add_column :curated_history_estimated_tokens, Integer, null: false, default: 0
+      add_column :curation_saved_estimated_tokens, Integer, null: false, default: 0
+      add_column :stripped_thinking_estimated_tokens, Integer, null: false, default: 0
+      add_column :archived_history_estimated_tokens, Integer, null: false, default: 0
+      add_column :archive_saved_estimated_tokens, Integer, null: false, default: 0
+      add_column :context_window_saved_estimated_tokens, Integer, null: false, default: 0
+      add_column :rag_injected_estimated_tokens, Integer, null: false, default: 0
+      add_column :system_prompt_estimated_tokens, Integer, null: false, default: 0
+      add_column :baseline_system_estimated_tokens, Integer, null: false, default: 0
+      add_column :tool_definition_estimated_tokens, Integer, null: false, default: 0
+      add_column :final_context_estimated_tokens, Integer, null: false, default: 0
+      add_column :loaded_history_message_count, Integer, null: false, default: 0
+      add_column :curated_history_message_count, Integer, null: false, default: 0
+      add_column :archived_history_message_count, Integer, null: false, default: 0
+      add_column :stripped_thinking_message_count, Integer, null: false, default: 0
+      add_column :context_window_message_count_before, Integer, null: false, default: 0
+      add_column :context_window_message_count_after, Integer, null: false, default: 0
+      add_column :rag_entry_count, Integer, null: false, default: 0
+      add_column :tool_definition_count, Integer, null: false, default: 0
+      add_column :context_accounting_status, String, size: 64, null: false, default: 'missing'
+      add_column :context_accounting_json, String, text: true
+    end
+
+    create_table(:llm_context_accounting_events) do
+      primary_key :id
+      String :uuid, size: 36, null: false, unique: true
+      foreign_key :message_inference_request_id, :llm_message_inference_requests, null: false, on_delete: :cascade
+      foreign_key :message_inference_response_id, :llm_message_inference_responses, null: true, on_delete: :set_null
+      foreign_key :message_inference_metric_id, :llm_message_inference_metrics, null: true, on_delete: :set_null
+      String :conversation_ref, size: 128
+      String :request_ref, size: 128, null: false
+      String :event_type, size: 64, null: false
+      String :component, size: 64, null: false
+      Integer :estimated_tokens_before, null: false, default: 0
+      Integer :estimated_tokens_after, null: false, default: 0
+      Integer :estimated_tokens_delta, null: false, default: 0
+      Integer :message_count_before, null: false, default: 0
+      Integer :message_count_after, null: false, default: 0
+      String :metadata_json, text: true
+      DateTime :recorded_at
+      DateTime :inserted_at, null: false, default: Sequel::CURRENT_TIMESTAMP
+
+      index :message_inference_request_id
+      index :message_inference_response_id
+      index :message_inference_metric_id
+      index :request_ref
+      index :conversation_ref
+      index %i[event_type component]
+      index :recorded_at
+    end
+  end
+
+  down do
+    drop_table(:llm_context_accounting_events)
+
+    alter_table(:llm_message_inference_metrics) do
+      drop_column :context_accounting_json
+      drop_column :context_accounting_status
+      drop_column :tool_definition_count
+      drop_column :rag_entry_count
+      drop_column :context_window_message_count_after
+      drop_column :context_window_message_count_before
+      drop_column :stripped_thinking_message_count
+      drop_column :archived_history_message_count
+      drop_column :curated_history_message_count
+      drop_column :loaded_history_message_count
+      drop_column :final_context_estimated_tokens
+      drop_column :tool_definition_estimated_tokens
+      drop_column :baseline_system_estimated_tokens
+      drop_column :system_prompt_estimated_tokens
+      drop_column :rag_injected_estimated_tokens
+      drop_column :context_window_saved_estimated_tokens
+      drop_column :archive_saved_estimated_tokens
+      drop_column :archived_history_estimated_tokens
+      drop_column :stripped_thinking_estimated_tokens
+      drop_column :curation_saved_estimated_tokens
+      drop_column :curated_history_estimated_tokens
+      drop_column :loaded_history_estimated_tokens
+      drop_column :request_message_estimated_tokens
+    end
+  end
+end

--- a/lib/legion/data/model.rb
+++ b/lib/legion/data/model.rb
@@ -21,7 +21,8 @@ module Legion
              rbac/role_assignments rbac/runner_grants rbac/cross_team_grants
              llm/conversation llm/message llm/message_inference_request
              llm/message_inference_response llm/route_attempt
-             llm/message_inference_metric llm/tool_call llm/tool_call_attempt
+             llm/message_inference_metric llm/context_accounting_event
+             llm/tool_call llm/tool_call_attempt
              llm/conversation_compaction llm/policy_evaluation
              llm/security_event llm/registry_event]
         end

--- a/lib/legion/data/models/llm/context_accounting_event.rb
+++ b/lib/legion/data/models/llm/context_accounting_event.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require_relative 'model_helpers'
+
+module Legion
+  module Data
+    module Models
+      module LLM
+        class ContextAccountingEvent < Sequel::Model(:llm_context_accounting_events)
+          include ModelHelpers
+
+          many_to_one :message_inference_request
+          many_to_one :message_inference_response
+          many_to_one :message_inference_metric
+        end
+      end
+    end
+  end
+end

--- a/lib/legion/data/models/llm/message_inference_metric.rb
+++ b/lib/legion/data/models/llm/message_inference_metric.rb
@@ -11,6 +11,7 @@ module Legion
 
           many_to_one :message_inference_request
           many_to_one :message_inference_response
+          one_to_many :context_accounting_events
 
           class << self
             def finance_usage_by_cost_center_model_day(cost_center: nil, model_key: nil, from: nil, to: nil)

--- a/lib/legion/data/version.rb
+++ b/lib/legion/data/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Data
-    VERSION = '1.10.4'
+    VERSION = '1.10.5'
   end
 end

--- a/lib/legion/data/version.rb
+++ b/lib/legion/data/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Data
-    VERSION = '1.10.3'
+    VERSION = '1.10.4'
   end
 end


### PR DESCRIPTION
## Summary

- Migration 135 adds 22 pipeline-estimated context token columns to `llm_message_inference_metrics` — making it the canonical source of truth for all token accounting (request messages, loaded/curated/archived history, thinking strip savings, context-window enforcement savings, RAG injection, system/baseline prompt, tool definitions, final context estimate).
- Creates `llm_context_accounting_events` table for drill-down evidence rows (not a second source of token truth — totals reconcile to the canonical metrics row).
- Adds `ContextAccountingEvent` model with FK associations and registers it in the model loader.
- Bumps version to 1.10.5.

## Test plan

- [x] `bundle exec rspec` — 433 examples, 0 failures
- [x] `bundle exec rubocop` — 275 files, 0 offenses
- [ ] Verify migration runs cleanly against existing production schema
- [ ] Confirm `llm_context_accounting_events` FK cascades work on request deletion