### PR TITLE
Drop (conversation_id, seq) unique on llm_messages — a conversation is a tree

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,6 +23,13 @@ Naming/VariableNumber:
     - lib/legion/data/connection.rb
 Legion/Framework/EagerSequelModel:
   Enabled: false
+# TaxonomyEnum validates LLM lane taxonomy (:tier/:type/:circuit_state). In
+# these paths `type:` is a Sequel column type (e.g. foreign_key type: :uuid) or
+# the extract API (type: :auto/:text) — not LLM taxonomy — so the cop misfires.
+Legion/Llm/TaxonomyEnum:
+  Exclude:
+    - 'lib/legion/data/migrations/**/*'
+    - 'spec/**/*'
 Metrics/BlockLength:
   Max: 100
   Exclude:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Legion::Data Changelog
 
+## [1.10.6] - 2026-07-03
+
+### Changed
+- Migration 136: drops the `(conversation_id, seq)` UNIQUE constraint on `llm_messages`, replacing it with a NON-unique composite index. A conversation is a tree, not a line — a single parent can legitimately have two children at the same depth (e.g. a failed branch and the branch that continued), so two distinct messages can share `(conversation_id, seq)` and that is truth, not a duplicate. The unique constraint rejected legitimate siblings and forced the centralized ledger into a racy `MAX(seq)+1` generation that collided under concurrent writers (`PG::UniqueViolation` on `llm_messages_conversation_id_seq_key`). Message identity remains guaranteed by the unique `uuid`; `seq` becomes descriptive tree-depth. On SQLite the constraint drop rebuilds the table (dropping the inline `uuid` UNIQUE), so the migration re-asserts the uuid unique index — a no-op on PostgreSQL where `DROP CONSTRAINT` is surgical.
+
 ## [1.10.5] - 2026-06-16
 
 ### Added

--- a/lib/legion/data.rb
+++ b/lib/legion/data.rb
@@ -112,7 +112,7 @@ module Legion
       def connected?
         Legion::Settings[:data][:connected] == true
       rescue StandardError => e
-        handle_exception(e, level: :debug, handled: true, operation: :connected?)
+        handle_exception(e, level: :warn, handled: true, operation: :connected?)
         false
       end
 

--- a/lib/legion/data/archiver.rb
+++ b/lib/legion/data/archiver.rb
@@ -97,18 +97,15 @@ module Legion
           total_rows = 0
           paths = []
 
-          loop do
-            batch_result = archive_batch(
-              conn:            conn,
-              table:           table,
-              cutoff:          cutoff,
-              batch_size:      batch_size,
-              batch_n:         batches + 1,
-              now:             now,
-              storage_backend: storage_backend
-            )
-            break unless batch_result
-
+          while (batch_result = archive_batch(
+            conn:            conn,
+            table:           table,
+            cutoff:          cutoff,
+            batch_size:      batch_size,
+            batch_n:         batches + 1,
+            now:             now,
+            storage_backend: storage_backend
+          ))
             batches += 1
             total_rows += batch_result[:row_count]
             paths << batch_result[:path]

--- a/lib/legion/data/extract/handlers/base.rb
+++ b/lib/legion/data/extract/handlers/base.rb
@@ -53,7 +53,7 @@ module Legion
               require gem_name
               true
             rescue LoadError => e
-              handle_exception(e, level: :debug, handled: true, operation: :extract_handler_available, handler: name, gem: gem_name)
+              handle_exception(e, level: :warn, handled: true, operation: :extract_handler_available, handler: name, gem: gem_name)
               false
             end
           end

--- a/lib/legion/data/migrations/136_drop_llm_messages_seq_unique.rb
+++ b/lib/legion/data/migrations/136_drop_llm_messages_seq_unique.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# The (conversation_id, seq) UNIQUE constraint modeled a conversation as a flat
+# line, but a conversation is a tree: a single parent can legitimately have two
+# children at the same depth (e.g. a failed branch and the branch that
+# succeeded), so two distinct messages can share the same (conversation_id, seq)
+# and that is TRUTH, not a duplicate. The unique constraint rejected those
+# legitimate siblings and forced the ledger into a racy MAX(seq)+1 generation
+# that collided under concurrent writers.
+#
+# Message identity is guaranteed by the unique `uuid` (producer-derived, stable
+# across redelivery). seq/parent become descriptive ordering data, so we keep a
+# NON-unique composite index for conversation-ordered reads.
+Sequel.migration do
+  up do
+    alter_table(:llm_messages) do
+      drop_constraint(:llm_messages_conversation_id_seq_key, type: :unique) # rubocop:disable Legion/Llm/TaxonomyEnum
+      add_index %i[conversation_id seq], name: :idx_llm_messages_conversation_seq
+    end
+    # SQLite emulates the constraint drop by rebuilding the table, which drops
+    # the inline `uuid` UNIQUE. Re-assert it so message identity/dedup is never
+    # lost. On PostgreSQL DROP CONSTRAINT is surgical and the original uuid index
+    # already exists, so this is a no-op there.
+    alter_table(:llm_messages) do
+      add_index :uuid, unique: true, name: :idx_llm_messages_uuid_unique, if_not_exists: true
+    end
+  end
+
+  down do
+    alter_table(:llm_messages) do
+      drop_index :uuid, name: :idx_llm_messages_uuid_unique, if_exists: true
+      drop_index %i[conversation_id seq], name: :idx_llm_messages_conversation_seq
+      add_unique_constraint %i[conversation_id seq], name: :llm_messages_conversation_id_seq_key
+    end
+  end
+end

--- a/lib/legion/data/migrations/136_drop_llm_messages_seq_unique.rb
+++ b/lib/legion/data/migrations/136_drop_llm_messages_seq_unique.rb
@@ -14,7 +14,7 @@
 Sequel.migration do
   up do
     alter_table(:llm_messages) do
-      drop_constraint(:llm_messages_conversation_id_seq_key, type: :unique) # rubocop:disable Legion/Llm/TaxonomyEnum
+      drop_constraint(:llm_messages_conversation_id_seq_key, type: :unique)
       add_index %i[conversation_id seq], name: :idx_llm_messages_conversation_seq
     end
     # SQLite emulates the constraint drop by rebuilding the table, which drops

--- a/lib/legion/data/models/function.rb
+++ b/lib/legion/data/models/function.rb
@@ -18,7 +18,7 @@ module Legion
 
           ::JSON.parse(embedding)
         rescue ::JSON::ParserError => e
-          handle_exception(e, level: :debug, handled: true, operation: :embedding_vector, id: self[:id])
+          handle_exception(e, level: :warn, handled: true, operation: :embedding_vector, id: self[:id])
           nil
         end
 

--- a/lib/legion/data/models/node.rb
+++ b/lib/legion/data/models/node.rb
@@ -17,7 +17,7 @@ module Legion
 
           Legion::JSON.load(metrics)
         rescue StandardError => e
-          handle_exception(e, level: :debug, handled: true, operation: :parsed_metrics, id: self[:id])
+          handle_exception(e, level: :warn, handled: true, operation: :parsed_metrics, id: self[:id])
           nil
         end
 
@@ -26,7 +26,7 @@ module Legion
 
           Legion::JSON.load(hosted_worker_ids)
         rescue StandardError => e
-          handle_exception(e, level: :debug, handled: true, operation: :parsed_hosted_worker_ids, id: self[:id])
+          handle_exception(e, level: :warn, handled: true, operation: :parsed_hosted_worker_ids, id: self[:id])
           []
         end
       end

--- a/lib/legion/data/settings.rb
+++ b/lib/legion/data/settings.rb
@@ -41,8 +41,8 @@ module Legion
           name:                          nil,
 
           # Logging
-          log:                           true,
-          query_log:                     true,
+          log:                           false,
+          query_log:                     false,
           log_connection_info:           false,
           log_warn_duration:             1,
           sql_log_level:                 'debug',

--- a/lib/legion/data/settings.rb
+++ b/lib/legion/data/settings.rb
@@ -41,8 +41,8 @@ module Legion
           name:                          nil,
 
           # Logging
-          log:                           false,
-          query_log:                     false,
+          log:                           true,
+          query_log:                     true,
           log_connection_info:           false,
           log_warn_duration:             1,
           sql_log_level:                 'debug',

--- a/lib/legion/data/version.rb
+++ b/lib/legion/data/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Data
-    VERSION = '1.10.5'
+    VERSION = '1.10.6'
   end
 end

--- a/spec/legion/data/connection_replicas_spec.rb
+++ b/spec/legion/data/connection_replicas_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Legion::Data::Connection do
   end
 
   # Build a minimal Sequel::Database double with the methods we call.
-  def fake_sequel_db(**_opts)
+  def fake_sequel_db(**)
     db = instance_double(Sequel::Database)
     allow(db).to receive(:extension)
     allow(db).to receive(:add_servers)

--- a/spec/legion/data/tls_spec.rb
+++ b/spec/legion/data/tls_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Legion::Data::Connection do
 
     before do
       stub_const('Legion::Crypt::TLS', Module.new do
-        def self.resolve(config, **_opts)
+        def self.resolve(config, **)
           if config[:enabled]
             { enabled: true, verify: :peer, ca: '/etc/ssl/ca.pem', cert: nil, key: nil }
           else
@@ -69,7 +69,7 @@ RSpec.describe Legion::Data::Connection do
         )
 
         stub_const('Legion::Crypt::TLS', Module.new do
-          def self.resolve(_config, **_opts)
+          def self.resolve(_config, **)
             { enabled: true, verify: :none, ca: nil, cert: nil, key: nil }
           end
         end)


### PR DESCRIPTION
## Problem

Production ledger crash under load:

```
Sequel::UniqueConstraintViolation: PG::UniqueViolation:
  duplicate key value violates unique constraint "llm_messages_conversation_id_seq_key"
  DETAIL: Key (conversation_id, seq)=(158938, 2) already exists.
```

The message nacks and retries forever ("asked 14 times").

## Root cause

`(conversation_id, seq)` UNIQUE (migration 078) modeled a conversation as a **flat line**. But a conversation is a **tree** — a single parent can legitimately have two children at the same depth:

```
a(1) -> b(2) -> c(3, failed branch)
              -> d(3) -> e(4)
```

`c` and `d` are both depth 3, both children of `b`. Two distinct messages (different uuids) that legitimately share `(conversation_id, seq)`. That is **truth, not a duplicate** — but the unique constraint rejects one of them.

Because `seq` had to be unique, the centralized ledger generated it via a racy `MAX(seq)+1` / `latest.seq+1` read-modify-write. Under concurrent consumers on a shared audit queue, two writers compute the same `seq` → collision → nack/retry loop. The `seq` integer is **not a true data point** — it's fabricated at write time in a place (a centralized sink receiving events from ~100k distributed producers) that cannot know the real ordering.

## Fix

Drop the `(conversation_id, seq)` unique constraint; keep a **non-unique** composite index for conversation-ordered reads. Message identity remains guaranteed by the existing unique `uuid` (producer-derived, stable across redelivery, and already the key for the ledger's coalescing upsert). Ordering/lineage lives in `parent_message_id` + `created_at`, which reflect the real tree.

## Cross-DB

Verified against the real migration chain (078 → 135 → 136) on SQLite and via generated PostgreSQL DDL:

- **PostgreSQL:** `ALTER TABLE llm_messages DROP CONSTRAINT llm_messages_conversation_id_seq_key` — surgical, touches nothing else.
- **SQLite:** emulates the drop by rebuilding the table, which drops the inline `uuid` UNIQUE — so the migration re-asserts the uuid unique index (`IF NOT EXISTS`, a no-op on PG).

Verified: after migration, two different-uuid messages can share `(conversation_id, seq)`, uuid uniqueness stays intact, and `down` restores the original constraint.

## Blast radius

- lex-llm-ledger already handles genuine redelivery via `ON CONFLICT (uuid) DO UPDATE` coalescing upsert (separate PR). This migration removes the constraint that was crashing; the ledger no longer needs to invent a collision-free integer.
- No data migration required — dropping a constraint, adding an index.